### PR TITLE
Explicit Python Version Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,12 @@ Intended Audience :: Developers
 License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
 License :: OSI Approved :: Zope Public License
 Programming Language :: Python
-Programming Language :: Python :: 3
+Programming Language :: Python :: 2.5
+Programming Language :: Python :: 2.6
+Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3.1
+Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
 Programming Language :: C
 Programming Language :: SQL
 Topic :: Database


### PR DESCRIPTION
Used supported versions from http://initd.org/psycopg/docs/install.html
