### PR TITLE
Fix compiling on Solaris 10, and illumos

### DIFF
--- a/psycopg/config.h
+++ b/psycopg/config.h
@@ -141,7 +141,7 @@ static int pthread_mutex_init(pthread_mutex_t *mutex, void* fake)
 #endif
 #endif
 
-#if (defined(__FreeBSD__) && __FreeBSD_version < 503000) || (defined(_WIN32) && !defined(__GNUC__)) || || (defined(sun) || defined(__sun__)) && (defined(__SunOS_5_8) || defined(__SunOS_5_9))
+#if (defined(__FreeBSD__) && __FreeBSD_version < 503000) || (defined(_WIN32) && !defined(__GNUC__)) || (defined(sun) || defined(__sun__)) && (defined(__SunOS_5_8) || defined(__SunOS_5_9))
 /* what's this, we have no round function either? */
 static double round(double num)
 {


### PR DESCRIPTION
Solaris 10+ has round, and illumos distributions like Joyent's SmartOS have `round` as well.
