### PR TITLE
correct handling of __eq__ comparison of ranges with non-ranges

### DIFF
--- a/lib/_range.py
+++ b/lib/_range.py
@@ -121,7 +121,7 @@ class Range(object):
         return self._bounds is not None
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, Range):
             return False
         return (self._lower == other._lower
             and self._upper == other._upper

--- a/tests/test_types_extras.py
+++ b/tests/test_types_extras.py
@@ -1216,6 +1216,15 @@ class RangeTestCase(unittest.TestCase):
         from psycopg2.extras import Range
         self.assertFalse(Range(10, 20)==())
 
+    def test_eq_subclass(self):
+        from psycopg2.extras import Range, NumericRange
+        
+        class IntRange(NumericRange): pass
+        class PositiveIntRange(IntRange): pass
+        
+        self.assertTrue(Range(10, 20)==IntRange(10, 20))
+        self.assertTrue(PositiveIntRange(10, 20)==IntRange(10, 20))
+
     def test_not_ordered(self):
         from psycopg2.extras import Range
         self.assertRaises(TypeError, lambda: Range(empty=True) < Range(0,4))


### PR DESCRIPTION
I originally thought a more useful error message was all that's needed, but it turns out that raising any exception here causes problems with SQLAlchemy's internal state tracking.
