### PR TITLE
Cast dict values to string before quoting them

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -644,7 +644,8 @@ class HstoreAdapter(object):
 
         k = _ext.adapt(self.wrapped.keys())
         k.prepare(self.conn)
-        v = _ext.adapt(self.wrapped.values())
+        values = [str(v) for v in self.wrapped.values()]
+        v = _ext.adapt(values)
         v.prepare(self.conn)
         return b("hstore(") + k.getquoted() + b(", ") + v.getquoted() + b(")")
 


### PR DESCRIPTION
The SQL hstore function requires key and value of type text.
