### PR TITLE
No implicit transactions for named with hold cursors outside their transaction

### DIFF
--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -871,7 +871,7 @@ pq_flush(connectionObject *conn)
 */
 
 RAISES_NEG int
-pq_execute(cursorObject *curs, const char *query, int async, int no_result)
+pq_execute(cursorObject *curs, const char *query, int async, int no_result, int no_begin)
 {
     PGresult *pgres = NULL;
     char *error = NULL;
@@ -894,7 +894,7 @@ pq_execute(cursorObject *curs, const char *query, int async, int no_result)
     Py_BEGIN_ALLOW_THREADS;
     pthread_mutex_lock(&(curs->conn->lock));
 
-    if (pq_begin_locked(curs->conn, &pgres, &error, &_save) < 0) {
+    if (!no_begin && pq_begin_locked(curs->conn, &pgres, &error, &_save) < 0) {
         pthread_mutex_unlock(&(curs->conn->lock));
         Py_BLOCK_THREADS;
         pq_complete_error(curs->conn, &pgres, &error);

--- a/psycopg/pqpath.h
+++ b/psycopg/pqpath.h
@@ -36,7 +36,7 @@
 HIDDEN PGresult *pq_get_last_result(connectionObject *conn);
 RAISES_NEG HIDDEN int pq_fetch(cursorObject *curs, int no_result);
 RAISES_NEG HIDDEN int pq_execute(cursorObject *curs, const char *query,
-                                 int async, int no_result);
+                                 int async, int no_result, int no_begin);
 HIDDEN int pq_send_query(connectionObject *conn, const char *query);
 HIDDEN int pq_begin_locked(connectionObject *conn, PGresult **pgres,
                            char **error, PyThreadState **tstate);


### PR DESCRIPTION
Hi,

I noticed that currently named "with hold" cursors behave differently than client-side cursors in some aspects, which seem to be a little off:
- When closing withhold cursor after its creating transaction is committed another transaction is implicitly started, which may unexpectedly leave connection is a long transaction
- When fetching data outside their transactions, again, an implicit transaction is started, when it seems it's not needed. Current documentation (http://www.postgresql.org/docs/current/static/sql-declare.html) currently says that it copies rows to temporary file/memory, and it seems to me (though I'm not entirely certain) that fetch would return data as it was in a transaction where cursor was created, not how it is in another transaction.

What do you think? Should implicit transactions always be created, or is it better to fetch/close in basically autocommit mode?
