### PR TITLE
Add __repr__ to Json object for better logging

### DIFF
--- a/lib/_json.py
+++ b/lib/_json.py
@@ -73,6 +73,9 @@ class Json(object):
         if proto is ISQLQuote:
             return self
 
+    def __repr__(self):
+        return self.dumps()
+
     def dumps(self, obj):
         """Serialize *obj* in JSON format.
 


### PR DESCRIPTION
Currently, attempt to log or print Json object uses default python's implementation which is useless. Using actual serialized content is much better.
