### PR TITLE
Use setuptools so bdist_wheel command is available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ import os
 import sys
 import re
 import subprocess
+from setuptools import Command
 from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils.sysconfig import get_python_inc


### PR DESCRIPTION
I've been using psycopg2 for some time and since use on Windows machines without installation privileges is a requirement, I've made the effort to build wheels of the most recent version 2.5.2.  

I had to make the following change to setup.py to allow me to execute the bdist_wheel command for building the wheels.  I'd be happy to push these into the pypi repository home for psycopg2, if you so desire.  These have been built on Python 2.7 against PostGres 9.3.2 in both 32-bit/64-bit varieties of Visual Studio 2008.

You can see the wheels on the testpypi server at: https://testpypi.python.org/pypi/psycopg2 
