### PR TITLE
Fixed DNS typo in examples

### DIFF
--- a/examples/binary.py
+++ b/examples/binary.py
@@ -24,7 +24,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/copy_from.py
+++ b/examples/copy_from.py
@@ -27,7 +27,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/copy_to.py
+++ b/examples/copy_to.py
@@ -27,7 +27,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/dt.py
+++ b/examples/dt.py
@@ -28,7 +28,7 @@ from psycopg2.extensions import adapt
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 curs = conn.cursor()
 

--- a/examples/encoding.py
+++ b/examples/encoding.py
@@ -26,7 +26,7 @@ import psycopg2.extensions
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Initial encoding for this connection is", conn.encoding
 

--- a/examples/fetch.py
+++ b/examples/fetch.py
@@ -24,7 +24,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/lastrowid.py
+++ b/examples/lastrowid.py
@@ -23,7 +23,7 @@ import sys, psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 curs = conn.cursor()
 

--- a/examples/lobject.py
+++ b/examples/lobject.py
@@ -24,7 +24,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/mogrify.py
+++ b/examples/mogrify.py
@@ -24,7 +24,7 @@ import sys, psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding

--- a/examples/notify.py
+++ b/examples/notify.py
@@ -26,7 +26,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -30,7 +30,7 @@ import psycopg2
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/threads.py
+++ b/examples/threads.py
@@ -45,7 +45,7 @@ if len(sys.argv) > 1:
 if len(sys.argv) > 2:
     MODE = int(sys.argv[2])
     
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 curs = conn.cursor()
 

--- a/examples/typecast.py
+++ b/examples/typecast.py
@@ -29,7 +29,7 @@ import psycopg2.extensions
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Encoding for this connection is", conn.encoding
 

--- a/examples/tz.py
+++ b/examples/tz.py
@@ -28,7 +28,7 @@ from psycopg2.tz import ZERO, LOCAL, FixedOffsetTimezone
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 curs = conn.cursor()
 

--- a/examples/usercast.py
+++ b/examples/usercast.py
@@ -33,7 +33,7 @@ import psycopg2.extras
 if len(sys.argv) > 1:
     DSN = sys.argv[1]
 
-print "Opening connection using dns:", DSN
+print "Opening connection using dsn:", DSN
 conn = psycopg2.connect(DSN)
 print "Initial encoding for this connection is", conn.encoding
 


### PR DESCRIPTION
Examples incorrectly talked about dns where dsn was meant.
