### PR TITLE
Use python3 notation for keyword-only arguments.

### DIFF
--- a/doc/src/connection.rst
+++ b/doc/src/connection.rst
@@ -348,7 +348,7 @@ The ``connection`` class
         pair: Transaction; Autocommit
         pair: Transaction; Isolation level
 
-    .. method:: set_session(*, isolation_level, readonly, deferrable, autocommit)
+    .. method:: set_session(*, isolation_level=None, readonly=None, deferrable=None, autocommit=None)
 
         Set one or more parameters for the next transactions or statements in
         the current session. See |SET TRANSACTION|_ for further details.


### PR DESCRIPTION
Sure, python2 users can understand that form.

The current version doesn't points the fact that args are keyword-only at all.
I read it as: you can use it like
  .set_session(isolation_level)
  or
  .set_session(readonly)
which is definitelly wrong.
