### PR TITLE
Modify hstore adaptor to only produce strings

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -644,7 +644,7 @@ class HstoreAdapter(object):
 
         k = _ext.adapt(self.wrapped.keys())
         k.prepare(self.conn)
-        v = _ext.adapt(self.wrapped.values())
+        v = _ext.adapt([unicode(x) if x is not None else None for x in self.wrapped.values()])
         v.prepare(self.conn)
         return b("hstore(") + k.getquoted() + b(", ") + v.getquoted() + b(")")
 


### PR DESCRIPTION
In short, the previous implementation would adapt some types into values incompatible with hstore. For example, a dictionary with a boolean value would cause a SQL error. Since hstore only accepts strings (and Null), everything needs to be cast down to a string representation.

Perhaps the question is: Should using non-string types be an error? If so, there should be a better error message. The prior implementation produced a SQL parser error.

This is probably not the best solution, so I would appreciate feedback.

Please see commit message for more detail on the change.
