### PR TITLE
Feature: cursor.callproc could accept Dict for PostgreSQL 9.0+ named parameters

### DIFF
--- a/doc/src/cursor.rst
+++ b/doc/src/cursor.rst
@@ -201,12 +201,17 @@ The ``cursor`` class
             
         Call a stored database procedure with the given name. The sequence of
         parameters must contain one entry for each argument that the procedure
-        expects. The result of the call is returned as modified copy of the
-        input sequence. Input parameters are left untouched, output and
-        input/output parameters replaced with possibly new values.
-        
-        The procedure may also provide a result set as output. This must then
-        be made available through the standard |fetch*|_ methods.
+        expects. Overloaded procedures are supported. Named parameters can be
+        used with a PostgreSQL 9.0+ client by supplying the sequence of
+        parameters as a Dict.
+
+        This function is, at present, not DBAPI-compliant. The return value is
+        supposed to consist of the sequence of parameters with modified output
+        and input/output parameters. In future versions, the DBAPI-compliant
+        return value may be implemented, but for now the function returns None.
+
+        The procedure may provide a result set as output. This is then made
+        available through the standard |fetch*|_ methods.
 
 
     .. method:: mogrify(operation [, parameters])

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1021,7 +1021,8 @@ _escape_identifier(PGconn *pgconn, const char *str, size_t length)
     rv = PQescapeIdentifier(pgconn, str, length);
     if (!rv) {
         char *msg;
-        if (!(msg = PQerrorMessage(pgconn))) {
+        msg = PQerrorMessage(pgconn);
+        if (!msg || !msg[0]) {
             msg = "no message provided";
         }
         PyErr_Format(InterfaceError, "failed to escape identifier: %s", msg);

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1064,6 +1064,13 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
       /* we will throw the sanitized C strings into a cache to not redo the work later */
       parameter_name_cstr_sanitized_CACHE = PyMem_New(char *, nparameters);
 
+      if (parameter_name_cstr_sanitized_CACHE == NULL) {
+        PyErr_NoMemory();
+        PyMem_Del(parameter_name_cstr_sanitized_CACHE);
+        Py_DECREF(parameter_names);
+        goto exit;
+      }
+
       for(i=0; i<nparameters; i++) {
         parameter_name = PyList_GetItem(parameter_names, i);
 

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1016,6 +1016,10 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     PyObject *operation = NULL;
     PyObject *res = NULL;
     PyObject *parameter_name = NULL;
+    PyObject *parameter_name_bytes = NULL;
+    char *parameter_name_cstr = NULL;
+    char *parameter_name_cstr_sanitized = NULL;
+    char **parameter_name_cstr_sanitized_CACHE = NULL;
     PyObject *parameter_names = NULL;
 
     if (!PyArg_ParseTuple(args, "s#|O",
@@ -1040,40 +1044,71 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
 
     /* allocate some memory, build the SQL and create a PyString from it */
 
+    /* a dict requires special handling: we put the parameter names into the SQL */
     if (nparameters > 0 && PyDict_Check(parameters)) {
-      /* for a dict, we put the parameter names into the SQL */
+
       parameter_names = PyDict_Keys(parameters);
 
-      /* first we need to figure out how much space we need for the SQL */
-      sl = procname_len + 17 + nparameters*5 - (nparameters ? 1 : 0);
+      /* first we need to ensure the dict's keys are text */
       for(i=0; i<nparameters; i++) {
-        parameter_name = PyList_GetItem(parameter_names, i);
-        if (!Text_Check(parameter_name)) {
-          PyErr_SetString(PyExc_TypeError, "argument 2 must have string keys if Dict");
+        if (!Text_Check(PyList_GetItem(parameter_names, i))) {
+          PyErr_SetString(PyExc_TypeError, "argument 2 must have only string keys if Dict");
+          Py_DECREF(parameter_names);
           goto exit;
         }
-        sl += strlen(Text_AsUTF8(parameter_name));
       }
+
+      /* we need one extra pass to determine the amount of memory to allocate for the SQL */
+      sl = procname_len + 17 + nparameters*5 - (nparameters ? 1 : 0);
+
+      /* we will throw the sanitized C strings into a cache to not redo the work later */
+      parameter_name_cstr_sanitized_CACHE = PyMem_New(char *, nparameters);
+
+      for(i=0; i<nparameters; i++) {
+        parameter_name = PyList_GetItem(parameter_names, i);
+
+        Py_INCREF(parameter_name);
+        parameter_name_bytes = psycopg_ensure_bytes(parameter_name);
+        parameter_name_cstr = Bytes_AsString(parameter_name_bytes);
+        parameter_name_cstr_sanitized = PQescapeIdentifier(self->conn->pgconn, parameter_name_cstr, strlen(parameter_name_cstr));
+        Py_DECREF(parameter_name);
+
+        /* must add the length of the sanitized string to the length of the SQL string */
+        sl += strlen(parameter_name_cstr_sanitized);
+
+        parameter_name_cstr_sanitized_CACHE[i] = parameter_name_cstr_sanitized;
+      }
+
+      Py_DECREF(parameter_names);
 
       sql = (char*)PyMem_Malloc(sl);
       if (sql == NULL) {
-          PyErr_NoMemory();
-          goto exit;
+        PyErr_NoMemory();
+        for(i=0; i<nparameters; i++) {
+          PQfreemem(parameter_name_cstr_sanitized_CACHE[i]);
+        }
+        PyMem_Del(parameter_name_cstr_sanitized_CACHE);
+        goto exit;
       }
 
       sprintf(sql, "SELECT * FROM %s(", procname);
       for(i=0; i<nparameters; i++) {
+        parameter_name_cstr_sanitized = parameter_name_cstr_sanitized_CACHE[i];
         /* like procname, param names are not sanitized. don't SQL inject yourself. */
-        strcat(sql, Text_AsUTF8(PyList_GetItem(parameter_names, i)));
+        strcat(sql, parameter_name_cstr_sanitized);
         strcat(sql, ":=%s,");
+
+        PQfreemem(parameter_name_cstr_sanitized);
       }
+      PyMem_Del(parameter_name_cstr_sanitized_CACHE);
       sql[sl-2] = ')';
       sql[sl-1] = '\0';
-      Py_DECREF(parameter_names);
 
       /* now that we have the query string we can discard the keys and proceed normally */
       parameters = PyDict_Values(parameters);
     }
+
+    /* a list (or None) is a little bit simpler */
     else {
       sl = procname_len + 17 + nparameters*3 - (nparameters ? 1 : 0);
 

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1015,6 +1015,7 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     PyObject *parameters = Py_None;
     PyObject *operation = NULL;
     PyObject *res = NULL;
+    PyObject *parameter_names = NULL;
 
     if (!PyArg_ParseTuple(args, "s#|O",
           &procname, &procname_len, &parameters
@@ -1037,19 +1038,52 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     }
 
     /* allocate some memory, build the SQL and create a PyString from it */
-    sl = procname_len + 17 + nparameters*3 - (nparameters ? 1 : 0);
-    sql = (char*)PyMem_Malloc(sl);
-    if (sql == NULL) {
-        PyErr_NoMemory();
-        goto exit;
-    }
 
-    sprintf(sql, "SELECT * FROM %s(", procname);
-    for(i=0; i<nparameters; i++) {
-        strcat(sql, "%s,");
+    if (nparameters > 0 && PyDict_Check(parameters)) {
+      /* for a dict, we put the parameter names into the SQL */
+      parameter_names = PyDict_Keys(parameters);
+
+      /* first we need to figure out how much space we need for the SQL */
+      sl = procname_len + 17 + nparameters*5 - (nparameters ? 1 : 0);
+      for(i=0; i<nparameters; i++) {
+        sl += strlen(Text_AsUTF8(PyList_GetItem(parameter_names, i)));
+      }
+
+      sql = (char*)PyMem_Malloc(sl);
+      if (sql == NULL) {
+          PyErr_NoMemory();
+          goto exit;
+      }
+
+      sprintf(sql, "SELECT * FROM %s(", procname);
+      for(i=0; i<nparameters; i++) {
+        /* like procname, param names are not sanitized. don't SQL inject yourself. */
+        strcat(sql, Text_AsUTF8(PyList_GetItem(parameter_names, i)));
+        strcat(sql, ":=%s,");
+      }
+      sql[sl-2] = ')';
+      sql[sl-1] = '\0';
+      Py_DECREF(parameter_names);
+
+      /* now that we have the query string we can discard the keys and proceed normally */
+      parameters = PyDict_Values(parameters);
     }
-    sql[sl-2] = ')';
-    sql[sl-1] = '\0';
+    else {
+      sl = procname_len + 17 + nparameters*3 - (nparameters ? 1 : 0);
+
+      sql = (char*)PyMem_Malloc(sl);
+      if (sql == NULL) {
+          PyErr_NoMemory();
+          goto exit;
+      }
+
+      sprintf(sql, "SELECT * FROM %s(", procname);
+      for(i=0; i<nparameters; i++) {
+          strcat(sql, "%s,");
+      }
+      sql[sl-2] = ')';
+      sql[sl-1] = '\0';
+    }
 
     if (!(operation = Bytes_FromString(sql))) { goto exit; }
 

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1132,8 +1132,9 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     if (0 <= _psyco_curs_execute(
             self, operation, pvals, self->conn->async, 0)) {
 
-      /* return None from this until it's DBAPI compliant... */
-      res = Py_None;
+        /* return None from this until it's DBAPI compliant... */
+        Py_INCREF(Py_None);
+        res = Py_None;
     }
 
 exit:

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1042,9 +1042,8 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     }
 
     if (parameters != Py_None) {
-        nparameters = PyObject_Length(parameters);
-        if (nparameters < 0) {
-            nparameters = 0;
+        if (-1 == (nparameters = PyObject_Length(parameters))) {
+            goto exit;
         }
     }
 

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1006,6 +1006,34 @@ exit:
 #define psyco_curs_callproc_doc \
 "callproc(procname, parameters=None) -- Execute stored procedure."
 
+/* Call PQescapeIdentifier.
+ *
+ * In case of error set a Python exception.
+ *
+ * TODO: this function can become more generic and go into utils
+ */
+static char *
+_escape_identifier(PGconn *pgconn, const char *str, size_t length)
+{
+    char *rv = NULL;
+
+#if PG_VERSION_HEX >= 0x090000
+    rv = PQescapeIdentifier(pgconn, str, length);
+    if (!rv) {
+        char *msg;
+        if (!(msg = PQerrorMessage(pgconn))) {
+            msg = "no message provided";
+        }
+        PyErr_Format(InterfaceError, "failed to escape identifier: %s", msg);
+    }
+#else
+    PyErr_Format(PyExc_NotImplementedError,
+        "named parameters require psycopg2 compiled against libpq 9.0+");
+#endif
+
+    return rv;
+}
+
 static PyObject *
 psyco_curs_callproc(cursorObject *self, PyObject *args)
 {
@@ -1013,17 +1041,15 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     char *sql = NULL;
     Py_ssize_t procname_len, i, nparameters = 0, sl = 0;
     PyObject *parameters = Py_None;
-    PyObject *pvals = NULL;
     PyObject *operation = NULL;
     PyObject *res = NULL;
 
     int using_dict;
-#if PG_VERSION_HEX >= 0x090000
     PyObject *pname = NULL;
     PyObject *pnames = NULL;
+    PyObject *pvals = NULL;
     char *cpname = NULL;
     char **scpnames = NULL;
-#endif
 
     if (!PyArg_ParseTuple(args, "s#|O", &procname, &procname_len,
                 &parameters)) {
@@ -1050,7 +1076,6 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
 
     /* a Dict is complicated; the parameter names go into the query */
     if (using_dict) {
-#if PG_VERSION_HEX >= 0x090000
         if (!(pnames = PyDict_Keys(parameters))) { goto exit; }
         if (!(pvals = PyDict_Values(parameters))) { goto exit; }
 
@@ -1074,7 +1099,7 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
             if (!(pname = psycopg_ensure_bytes(pname))) { goto exit; }
             if (!(cpname = Bytes_AsString(pname))) { goto exit; }
 
-            if (!(scpnames[i] = PQescapeIdentifier(
+            if (!(scpnames[i] = _escape_identifier(
                     self->conn->pgconn, cpname, strlen(cpname)))) {
                 goto exit;
             }
@@ -1096,12 +1121,6 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
         }
         sql[sl-2] = ')';
         sql[sl-1] = '\0';
-
-#else
-        PyErr_SetString(PyExc_NotImplementedError,
-            "named parameters require psycopg2 compiled against libpq 9.0+");
-        goto exit;
-#endif
     }
 
     /* a list (or None, or empty data structure) is a little bit simpler */
@@ -1138,7 +1157,6 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     }
 
 exit:
-#if PG_VERSION_HEX >= 0x090000
     if (scpnames != NULL) {
         for (i = 0; i < nparameters; i++) {
             if (scpnames[i] != NULL) {
@@ -1149,7 +1167,6 @@ exit:
     PyMem_Del(scpnames);
     Py_XDECREF(pname);
     Py_XDECREF(pnames);
-#endif
     Py_XDECREF(operation);
     Py_XDECREF(pvals);
     PyMem_Free((void*)sql);

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1015,6 +1015,7 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     PyObject *parameters = Py_None;
     PyObject *operation = NULL;
     PyObject *res = NULL;
+    PyObject *parameter_name = NULL;
     PyObject *parameter_names = NULL;
 
     if (!PyArg_ParseTuple(args, "s#|O",
@@ -1046,7 +1047,12 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
       /* first we need to figure out how much space we need for the SQL */
       sl = procname_len + 17 + nparameters*5 - (nparameters ? 1 : 0);
       for(i=0; i<nparameters; i++) {
-        sl += strlen(Text_AsUTF8(PyList_GetItem(parameter_names, i)));
+        parameter_name = PyList_GetItem(parameter_names, i);
+        if (!Text_Check(parameter_name)) {
+          PyErr_SetString(PyExc_TypeError, "argument 2 must have string keys if Dict");
+          goto exit;
+        }
+        sl += strlen(Text_AsUTF8(parameter_name));
       }
 
       sql = (char*)PyMem_Malloc(sl);

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1054,8 +1054,6 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     if (using_dict) {
 #if PG_VERSION_HEX >= 0x090000
         if (!(pnames = PyDict_Keys(parameters))) {
-            PyErr_SetString(PyExc_RuntimeError,
-                    "built-in 'keys' failed on a Dict!");
             goto exit;
         }
 
@@ -1073,36 +1071,26 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
             /* all errors are RuntimeErrors as they should never occur */
 
             if (!(pname = PyList_GetItem(pnames, i))) {
-                PyErr_SetString(PyExc_RuntimeError,
-                        "built-in 'values' did not return List!");
                 goto exit;
             }
 
             if (!(spname = PyObject_Str(pname))) {
-                PyErr_SetString(PyExc_RuntimeError,
-                        "built-in 'str' failed!");
                 goto exit;
             }
 
             /* this is the only function here that returns a new reference */
             if (!(bpname = psycopg_ensure_bytes(spname))) {
-                PyErr_SetString(PyExc_RuntimeError,
-                        "failed to get Bytes from text!");
                 goto exit;
             }
 
             if (!(cpname = Bytes_AsString(bpname))) {
                 Py_XDECREF(bpname);
-                PyErr_SetString(PyExc_RuntimeError,
-                        "failed to get cstr from Bytes!");
                 goto exit;
             }
 
             if (!(scpnames[i] = PQescapeIdentifier(self->conn->pgconn, cpname,
                         strlen(cpname)))) {
                 Py_XDECREF(bpname);
-                PyErr_SetString(PyExc_RuntimeError,
-                        "libpq failed to escape identifier!");
                 goto exit;
             }
 
@@ -1126,8 +1114,6 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
         sql[sl-1] = '\0';
 
         if (!(parameters = PyDict_Values(parameters))) {
-            PyErr_SetString(PyExc_RuntimeError,
-                    "built-in 'values' failed on a Dict!");
             goto exit;
         }
 #else

--- a/psycopg/python.h
+++ b/psycopg/python.h
@@ -71,12 +71,14 @@ typedef unsigned long Py_uhash_t;
 #define Text_Format(f,a) PyString_Format(f,a)
 #define Text_FromUTF8(s) PyString_FromString(s)
 #define Text_FromUTF8AndSize(s,n) PyString_FromStringAndSize(s,n)
+#define Text_AsUTF8(s) PyString_AsString(s)
 #else
 #define Text_Type PyUnicode_Type
 #define Text_Check(s) PyUnicode_Check(s)
 #define Text_Format(f,a) PyUnicode_Format(f,a)
 #define Text_FromUTF8(s) PyUnicode_FromString(s)
 #define Text_FromUTF8AndSize(s,n) PyUnicode_FromStringAndSize(s,n)
+#define Text_AsUTF8(s) PyUnicode_AsUTF8(s)
 #endif
 
 #if PY_MAJOR_VERSION > 2

--- a/psycopg/python.h
+++ b/psycopg/python.h
@@ -71,14 +71,12 @@ typedef unsigned long Py_uhash_t;
 #define Text_Format(f,a) PyString_Format(f,a)
 #define Text_FromUTF8(s) PyString_FromString(s)
 #define Text_FromUTF8AndSize(s,n) PyString_FromStringAndSize(s,n)
-#define Text_AsUTF8(s) PyString_AsString(s)
 #else
 #define Text_Type PyUnicode_Type
 #define Text_Check(s) PyUnicode_Check(s)
 #define Text_Format(f,a) PyUnicode_Format(f,a)
 #define Text_FromUTF8(s) PyUnicode_FromString(s)
 #define Text_FromUTF8AndSize(s,n) PyUnicode_FromStringAndSize(s,n)
-#define Text_AsUTF8(s) PyUnicode_AsUTF8(s)
 #endif
 
 #if PY_MAJOR_VERSION > 2

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -465,6 +465,11 @@ class CursorTests(ConnectingTestCase):
             self.assertRaises(exception, cur.callproc, procname, parameter_sequence)
             self.conn.rollback()
 
+    def test_callproc_badparam(self):
+        cur = self.conn.cursor()
+        self.assertRaises(TypeError, cur.callproc, 'lower', 42)
+
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -457,9 +457,9 @@ class CursorTests(ConnectingTestCase):
             ({ paramname: 2, 'foo': 'bar' }, psycopg2.ProgrammingError),
             ({ paramname: '2' },             psycopg2.ProgrammingError),
             ({ paramname: 'two' },           psycopg2.ProgrammingError),
-            ({ 'bjørn': 2 },                 psycopg2.ProgrammingError),
-            ({ 3: 2 },                       psycopg2.ProgrammingError),
-            ({ self: 2 },                    psycopg2.ProgrammingError),
+            ({ u'bj\xc3rn': 2 },             psycopg2.ProgrammingError),
+            ({ 3: 2 },                       TypeError),
+            ({ self: 2 },                    TypeError),
         ]
         for parameter_sequence, exception in failing_cases:
             self.assertRaises(exception, cur.callproc, procname, parameter_sequence)

--- a/tests/test_psycopg2_dbapi20.py
+++ b/tests/test_psycopg2_dbapi20.py
@@ -36,6 +36,29 @@ class Psycopg2Tests(dbapi20.DatabaseAPI20Test):
     connect_kw_args = {'dsn': dsn}
 
     lower_func = 'lower' # For stored procedure test
+    def test_callproc(self):
+        # Until DBAPI 2.0 compliance, callproc should return None or it's just
+        # misleading. Therefore, we will skip the return value test for
+        # callproc and only perform the fetch test.
+        #
+        # For what it's worth, the DBAPI2.0 test_callproc doesn't actually
+        # test for DBAPI2.0 compliance! It doesn't check for modified OUT and
+        # IN/OUT parameters in the return values!
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            if self.lower_func and hasattr(cur,'callproc'):
+                cur.callproc(self.lower_func,('FOO',))
+                r = cur.fetchall()
+                self.assertEqual(len(r),1,'callproc produced no result set')
+                self.assertEqual(len(r[0]),1,
+                    'callproc produced invalid result set'
+                    )
+                self.assertEqual(r[0][0],'foo',
+                    'callproc produced invalid results'
+                    )
+        finally:
+            con.close()
 
     def test_setoutputsize(self):
         # psycopg2's setoutputsize() is a no-op


### PR DESCRIPTION
Starting with PostgreSQL 9.0, functions can be called using "named parameters": https://wiki.postgresql.org/wiki/What's_new_in_PostgreSQL_9.0#Named_Parameter_Calls

This is especially useful for functions with a large number of arguments, as it allows you to refer to the arguments by name instead of having to remember their order. This small patch allows cursor.callproc to accept a Dict instead of a List to mirror PostgreSQL's feature. No previous functionality has been removed. 

Like the name of the stored procedure itself, the names of the parameters are NOT sanitized. This means that, just as the programmer should not expose control of the name of the stored procedure to the end user, the programmer should not expose control of the parameter names either.

A macro was added to python.h for the python-version-agnostic conversion of text objects into C char arrays (specifically the procedure parameter names, which come from the Dict keys.)

The code compiles and runs correctly under Python 2.7 and Python 3. There were no existing test suites for callproc (that I could find) so I wasn't sure where to put test suites for this new functionality. I used the following code to test:

https://gist.github.com/mrmilosz/905a4492216052821c38

Any procedure returning a value and matching the prototype will work for the test.

Thank you for your time. I hope you can make this patch a part of the trunk as it introduces a feature I would very much like to use! Of course, if I made any silly mistakes you are free to fix them first. For what it's worth I tried to pay close attention to my new/borrowed references and Py_DECREFs, but I am new to the Python C API.