### PR TITLE
Add context manager for connection pool for use with the with statement

### DIFF
--- a/lib/pool.py
+++ b/lib/pool.py
@@ -32,6 +32,20 @@ class PoolError(psycopg2.Error):
     pass
 
 
+class ConnectionContext(object):
+
+    def __init__(self, pool):
+        self.pool = pool
+        self._conn = None
+
+    def __enter__(self):
+        self._conn = self.pool.getconn()
+        return self._conn
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.pool.putconn(self._conn)
+
+
 class AbstractConnectionPool(object):
     """Generic key-based pooling code."""
 
@@ -57,6 +71,9 @@ class AbstractConnectionPool(object):
         for i in range(self.minconn):
             self._connect()
 
+    def __call__(self):
+        return ConnectionContext(self)
+
     def _connect(self, key=None):
         """Create a new connection and assign it to 'key' if not None."""
         conn = psycopg2.connect(*self._args, **self._kwargs)
@@ -76,7 +93,7 @@ class AbstractConnectionPool(object):
         """Get a free connection and assign it to 'key' if not None."""
         if self.closed: raise PoolError("connection pool is closed")
         if key is None: key = self._getkey()
-	
+
         if key in self._used:
             return self._used[key]
 
@@ -88,7 +105,7 @@ class AbstractConnectionPool(object):
             if len(self._used) == self.maxconn:
                 raise PoolError("connection pool exausted")
             return self._connect(key)
-		 
+ 
     def _putconn(self, conn, key=None, close=False):
         """Put away a connection."""
         if self.closed: raise PoolError("connection pool is closed")


### PR DESCRIPTION
Hi devs!

I really enjoy using context managers for connections and cursors, but it's kind of a pain to do this with connection pooling. This adds the ability to do this, and works like so:

```
pool = SimpleConnectionPool(...)

def work():
    with pool() as conn:
        # Use connection normally, it'll automatically be put back into the pool when complete
```

I'm open to suggestions with the interface -- the `__call__` seemed the least contentious with the existing method names. Let me know what you think.

Cheers,
Justin