### PR TITLE
Use lseek64 and ltell64 to support large object greater than 2gb in size...

### DIFF
--- a/psycopg/lobject.h
+++ b/psycopg/lobject.h
@@ -60,8 +60,8 @@ RAISES_NEG HIDDEN int lobject_export(lobjectObject *self, const char *filename);
 RAISES_NEG HIDDEN Py_ssize_t lobject_read(lobjectObject *self, char *buf, size_t len);
 RAISES_NEG HIDDEN Py_ssize_t lobject_write(lobjectObject *self, const char *buf,
                                 size_t len);
-RAISES_NEG HIDDEN int lobject_seek(lobjectObject *self, int pos, int whence);
-RAISES_NEG HIDDEN int lobject_tell(lobjectObject *self);
+RAISES_NEG HIDDEN long lobject_seek(lobjectObject *self, long pos, int whence);
+RAISES_NEG HIDDEN long lobject_tell(lobjectObject *self);
 RAISES_NEG HIDDEN int lobject_truncate(lobjectObject *self, size_t len);
 RAISES_NEG HIDDEN int lobject_close(lobjectObject *self);
 

--- a/psycopg/lobject_int.c
+++ b/psycopg/lobject_int.c
@@ -378,21 +378,21 @@ lobject_read(lobjectObject *self, char *buf, size_t len)
 
 /* lobject_seek - move the current position in the lo */
 
-RAISES_NEG int
-lobject_seek(lobjectObject *self, int pos, int whence)
+RAISES_NEG long
+lobject_seek(lobjectObject *self, long pos, int whence)
 {
     PGresult *pgres = NULL;
     char *error = NULL;
-    int where;
+    long where;
 
-    Dprintf("lobject_seek: fd = %d, pos = %d, whence = %d",
+    Dprintf("lobject_seek: fd = %d, pos = %Ld, whence = %d",
             self->fd, pos, whence);
 
     Py_BEGIN_ALLOW_THREADS;
     pthread_mutex_lock(&(self->conn->lock));
 
-    where = lo_lseek(self->conn->pgconn, self->fd, pos, whence);
-    Dprintf("lobject_seek: where = %d", where);
+    where = lo_lseek64(self->conn->pgconn, self->fd, pos, whence);
+    Dprintf("lobject_seek: where = %Ld", where);
     if (where < 0)
         collect_error(self->conn, &error);
 
@@ -406,20 +406,20 @@ lobject_seek(lobjectObject *self, int pos, int whence)
 
 /* lobject_tell - tell the current position in the lo */
 
-RAISES_NEG int
+RAISES_NEG long
 lobject_tell(lobjectObject *self)
 {
     PGresult *pgres = NULL;
     char *error = NULL;
-    int where;
+    long where;
 
     Dprintf("lobject_tell: fd = %d", self->fd);
 
     Py_BEGIN_ALLOW_THREADS;
     pthread_mutex_lock(&(self->conn->lock));
 
-    where = lo_tell(self->conn->pgconn, self->fd);
-    Dprintf("lobject_tell: where = %d", where);
+    where = lo_tell64(self->conn->pgconn, self->fd);
+    Dprintf("lobject_tell: where = %Ld", where);
     if (where < 0)
         collect_error(self->conn, &error);
 

--- a/psycopg/lobject_type.c
+++ b/psycopg/lobject_type.c
@@ -123,7 +123,7 @@ static PyObject *
 psyco_lobj_read(lobjectObject *self, PyObject *args)
 {
     PyObject *res;
-    int where, end;
+    long where, end;
     Py_ssize_t size = -1;
     char *buffer;
 
@@ -167,10 +167,10 @@ psyco_lobj_read(lobjectObject *self, PyObject *args)
 static PyObject *
 psyco_lobj_seek(lobjectObject *self, PyObject *args)
 {
-    int offset, whence=0;
-    int pos=0;
+    long offset, pos=0;
+    int whence=0;
 
-    if (!PyArg_ParseTuple(args, "i|i", &offset, &whence))
+    if (!PyArg_ParseTuple(args, "l|i", &offset, &whence))
         return NULL;
 
     EXC_IF_LOBJ_CLOSED(self);
@@ -180,7 +180,7 @@ psyco_lobj_seek(lobjectObject *self, PyObject *args)
     if ((pos = lobject_seek(self, offset, whence)) < 0)
         return NULL;
 
-    return PyInt_FromLong((long)pos);
+    return PyLong_FromLong(pos);
 }
 
 /* tell method - tell current position in the lobject */
@@ -191,7 +191,7 @@ psyco_lobj_seek(lobjectObject *self, PyObject *args)
 static PyObject *
 psyco_lobj_tell(lobjectObject *self, PyObject *args)
 {
-    int pos;
+    long pos;
 
     EXC_IF_LOBJ_CLOSED(self);
     EXC_IF_LOBJ_LEVEL0(self);
@@ -200,7 +200,7 @@ psyco_lobj_tell(lobjectObject *self, PyObject *args)
     if ((pos = lobject_tell(self)) < 0)
         return NULL;
 
-    return PyInt_FromLong((long)pos);
+    return PyLong_FromLong(pos);
 }
 
 /* unlink method - unlink (destroy) the lobject */


### PR DESCRIPTION
If a large object is greater than 2gb then calls to seek and tell will fail with an OperationError. This is because of the use of lseek and ltell instead of the lseek64 and ltell64.

Replaces lseek and ltell with lseek64 and ltell64 respectively. lobject_seek and lobject_tell modified to use long instead of int.
