### PR TITLE
Allow pickling of cursor.description

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -55,6 +55,7 @@ from psycopg2._psycopg import DateFromTicks, TimeFromTicks, TimestampFromTicks
 from psycopg2._psycopg import Error, Warning, DataError, DatabaseError, ProgrammingError
 from psycopg2._psycopg import IntegrityError, InterfaceError, InternalError
 from psycopg2._psycopg import NotSupportedError, OperationalError
+from psycopg2._psycopg import Column
 
 from psycopg2._psycopg import _connect, apilevel, threadsafety, paramstyle
 from psycopg2._psycopg import __version__

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -880,6 +880,7 @@ INIT_MODULE(_psycopg)(void)
     PyModule_AddObject(module, "List", (PyObject*)&listType);
     PyModule_AddObject(module, "QuotedString", (PyObject*)&qstringType);
     PyModule_AddObject(module, "lobject", (PyObject*)&lobjectType);
+    PyModule_AddObject(module, "Column", psyco_DescriptionType);
 
     /* encodings dictionary in module dictionary */
     PyModule_AddObject(module, "encodings", psycoEncodings);

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -23,6 +23,7 @@
 # License for more details.
 
 import time
+import pickle
 import psycopg2
 import psycopg2.extensions
 from psycopg2.extensions import b
@@ -399,6 +400,16 @@ class CursorTests(ConnectingTestCase):
         self.assert_(c.internal_size > 0)
         self.assertEqual(c.precision, None)
         self.assertEqual(c.scale, None)
+
+    def test_pickle_description(self):
+        curs = self.conn.cursor()
+        curs.execute('SELECT 1 AS foo')
+        description = curs.description
+
+        pickled = pickle.dumps(description, pickle.HIGHEST_PROTOCOL)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual(description, unpickled)
 
     @skip_before_postgres(8, 0)
     def test_named_cursor_stealing(self):


### PR DESCRIPTION
This is for people using dtuple.py; a dtuple.DatabaseTuple instance keeps a reference to cursor.description, which is not picklable because psycopg2 doesn't export the Column namedtuple it uses.

This commit exports the Column namedtuple, and includes a test to verify the pickle/unpickle works after exporting Column.