### PR TITLE
Cast time into timetz when the tzinfo field is set.

### DIFF
--- a/psycopg/adapter_datetime.c
+++ b/psycopg/adapter_datetime.c
@@ -62,7 +62,10 @@ _pydatetime_string_date_time(pydatetimeObject *self)
     char *fmt = NULL;
     switch (self->type) {
     case PSYCO_DATETIME_TIME:
-        fmt = "'%s'::time";
+        tz = PyObject_GetAttrString(self->wrapped, "tzinfo");
+        if (!tz) { goto error; }
+        fmt = (tz == Py_None) ? "'%s'::time" : "'%s'::timetz";
+        Py_DECREF(tz);
         break;
     case PSYCO_DATETIME_DATE:
         fmt = "'%s'::date";

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -287,7 +287,17 @@ class DatetimeTests(ConnectingTestCase, CommonDatetimeTestsMixin):
 
     def test_type_roundtrip_time(self):
         from datetime import time
-        self._test_type_roundtrip(time(10,20,30))
+        tm = self._test_type_roundtrip(time(10,20,30))
+        self.assertEqual(None, tm.tzinfo)
+
+    def test_type_roundtrip_timetz(self):
+        from datetime import time
+        import psycopg2.tz
+        tz = psycopg2.tz.FixedOffsetTimezone(8*60)
+        tm1 = time(10,20,30, tzinfo=tz)
+        tm2 = self._test_type_roundtrip(tm1)
+        self.assertNotEqual(None, tm2.tzinfo)
+        self.assertEqual(tm1, tm2)
 
     def test_type_roundtrip_interval(self):
         from datetime import timedelta


### PR DESCRIPTION
I found a bug that psycopg2 casts timezone-aware `datetime.time` objects into `time`, not `timetz` when they're compiled to SQL. This patch fixes it and for this work I consulted the previous commit(5e3f240ac96ddb27dee4cb03f1c857be1ced8ff9) pertaining to the `timestamptz` which is in same context with current issue.
