### PR TITLE
Correct exausted -> exhausted typo in exception

### DIFF
--- a/lib/pool.py
+++ b/lib/pool.py
@@ -86,7 +86,7 @@ class AbstractConnectionPool(object):
             return conn
         else:
             if len(self._used) == self.maxconn:
-                raise PoolError("connection pool exausted")
+                raise PoolError("connection pool exhausted")
             return self._connect(key)
 		 
     def _putconn(self, conn, key=None, close=False):


### PR DESCRIPTION
It caused a bit of confusion when trying to search through logs.
