### PR TITLE
Notify example should pop oldest message in conn.notifies, not newest

### DIFF
--- a/doc/src/advanced.rst
+++ b/doc/src/advanced.rst
@@ -291,7 +291,7 @@ something to read::
         else:
             conn.poll()
             while conn.notifies:
-                notify = conn.notifies.pop()
+                notify = conn.notifies.pop(0)
                 print "Got NOTIFY:", notify.pid, notify.channel, notify.payload
 
 Running the script and executing a command such as :sql:`NOTIFY test, 'hello'`


### PR DESCRIPTION
The example in the docs of handling LISTEN/NOTIFY does a conn.notifies.pop(), which will pull the most-recently-received notification, rather than the oldest un-popped notification, if more than one is waiting.  I think most users would prefer to receive notifications in the order they were sent, so I've updated the example to provide that behavior by doing conn.notifies.pop(0).