### PR TITLE
Add parse_dsn module function

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -12,6 +12,17 @@
 The module contains a few objects and function extending the minimum set of
 functionalities defined by the |DBAPI|_.
 
+.. function:: parse_dsn(dsn)
+
+    Parse connection string into a dictionary of keywords and values.
+
+    Uses libpq's ``PQconninfoParse`` to parse the string according to
+    accepted format(s) and check for supported keywords.
+
+    Example::
+
+        >>> psycopg2.extensions.parse_dsn('dbname=test user=postgres password=secret')
+        {'password': 'secret', 'user': 'postgres', 'dbname': 'test'}
 
 .. class:: connection(dsn, async=False)
 

--- a/doc/src/module.rst
+++ b/doc/src/module.rst
@@ -78,6 +78,7 @@ The module interface respects the standard defined in the |DBAPI|_.
 
     .. seealso::
 
+        - `parse_dsn`
         - libpq `connection string syntax`__
         - libpq supported `connection parameters`__
         - libpq supported `environment variables`__
@@ -91,6 +92,17 @@ The module interface respects the standard defined in the |DBAPI|_.
         The parameters *connection_factory* and *async* are Psycopg extensions
         to the |DBAPI|.
 
+.. function:: parse_dsn(dsn)
+
+    Parse connection string into a dictionary of keywords and values.
+
+    Uses libpq's ``PQconninfoParse`` to parse the string according to
+    accepted format(s) and check for supported keywords.
+
+    Example::
+
+        >>> psycopg2.parse_dsn('dbname=test user=postgres password=secret')
+        {'password': 'secret', 'user': 'postgres', 'dbname': 'test'}
 
 .. data:: apilevel
 

--- a/doc/src/module.rst
+++ b/doc/src/module.rst
@@ -78,7 +78,7 @@ The module interface respects the standard defined in the |DBAPI|_.
 
     .. seealso::
 
-        - `parse_dsn`
+        - `~psycopg2.extensions.parse_dsn`
         - libpq `connection string syntax`__
         - libpq supported `connection parameters`__
         - libpq supported `environment variables`__
@@ -91,18 +91,6 @@ The module interface respects the standard defined in the |DBAPI|_.
 
         The parameters *connection_factory* and *async* are Psycopg extensions
         to the |DBAPI|.
-
-.. function:: parse_dsn(dsn)
-
-    Parse connection string into a dictionary of keywords and values.
-
-    Uses libpq's ``PQconninfoParse`` to parse the string according to
-    accepted format(s) and check for supported keywords.
-
-    Example::
-
-        >>> psycopg2.parse_dsn('dbname=test user=postgres password=secret')
-        {'password': 'secret', 'user': 'postgres', 'dbname': 'test'}
 
 .. data:: apilevel
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -56,7 +56,7 @@ from psycopg2._psycopg import Error, Warning, DataError, DatabaseError, Programm
 from psycopg2._psycopg import IntegrityError, InterfaceError, InternalError
 from psycopg2._psycopg import NotSupportedError, OperationalError
 
-from psycopg2._psycopg import _connect, parse_dsn, apilevel, threadsafety, paramstyle
+from psycopg2._psycopg import _connect, apilevel, threadsafety, paramstyle
 from psycopg2._psycopg import __version__
 
 from psycopg2 import tz

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -56,7 +56,7 @@ from psycopg2._psycopg import Error, Warning, DataError, DatabaseError, Programm
 from psycopg2._psycopg import IntegrityError, InterfaceError, InternalError
 from psycopg2._psycopg import NotSupportedError, OperationalError
 
-from psycopg2._psycopg import _connect, apilevel, threadsafety, paramstyle
+from psycopg2._psycopg import _connect, parse_dsn, apilevel, threadsafety, paramstyle
 from psycopg2._psycopg import __version__
 
 from psycopg2 import tz

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -56,7 +56,7 @@ try:
 except ImportError:
     pass
 
-from psycopg2._psycopg import adapt, adapters, encodings, connection, cursor, lobject, Xid
+from psycopg2._psycopg import adapt, adapters, encodings, connection, cursor, lobject, Xid, parse_dsn
 from psycopg2._psycopg import string_types, binary_types, new_type, new_array_type, register_type
 from psycopg2._psycopg import ISQLQuote, Notify, Diagnostics, Column
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -278,6 +278,9 @@ class ConnectionTests(ConnectingTestCase):
                          dict(user='tester', password='secret', dbname='test'),
                          "simple DSN parsed")
 
+        self.assertRaises(ProgrammingError, parse_dsn,
+                          "dbname=test 2 user=tester password=secret")
+
         self.assertEqual(parse_dsn("dbname='test 2' user=tester password=secret"),
                          dict(user='tester', password='secret', dbname='test 2'),
                          "DSN with quoting parsed")


### PR DESCRIPTION
Calls PQconninfoParse to parse the dsn into a list of keyword and value
structs, then constructs a dictionary from that.  Can be useful when one
needs to alter some part of the the connection string reliably, but
doesn't want to get into all the details of parsing a dsn string:
quoting, URL format, etc.