### PR TITLE
Import ujson when available for speed improvements on large hstore

### DIFF
--- a/lib/_json.py
+++ b/lib/_json.py
@@ -34,13 +34,16 @@ from psycopg2._psycopg import new_type, new_array_type, register_type
 
 
 # import the best json implementation available
-if sys.version_info[:2] >= (2,6):
-    import json
-else:
-    try:
-        import simplejson as json
-    except ImportError:
-        json = None
+try:
+    import ujson as json
+except ImportError:
+    if sys.version_info[:2] >= (2,6):
+        import json
+    else:
+        try:
+            import simplejson as json
+        except ImportError:
+            json = None
 
 
 # oids from PostgreSQL 9.2


### PR DESCRIPTION
I recently ran into a situation where my ORM was inappropriately loading large hstore hashes when I wasn't necessarily going to use them. As a result, I started debugging performance of a json load from psycopg2 and found that I could get dramatic speedup when I /did/ want to load these large hstore dictionaries by using ujson instead of the base json module.
Adding an optional dependency of ujson should allow users who want it to improve their hstore and json type performance.
One caveat:
I don't know how you want this handled in terms of the test suites.
Is there a clever way to write the unit tests so that you can run the unit tests twice with and without the ujson module available to import? or do we assume that it's "just another testing configuration" - the equivalent of testing on 2.6 versus 2.7?