### PR TITLE
Fixes for MSVC 2015 (Python 3.5)

### DIFF
--- a/psycopg/config.h
+++ b/psycopg/config.h
@@ -142,15 +142,19 @@ static int pthread_mutex_init(pthread_mutex_t *mutex, void* fake)
 #endif
 #endif
 
+/* what's this, we have no round function either? */
 #if (defined(__FreeBSD__) && __FreeBSD_version < 503000) \
     || (defined(_WIN32) && !defined(__GNUC__)) \
     || (defined(sun) || defined(__sun__)) \
         && (defined(__SunOS_5_8) || defined(__SunOS_5_9))
-/* what's this, we have no round function either? */
+
+/* round has been added in the standard library with MSVC 2015 */
+#if _MSC_VER < 1900
 static double round(double num)
 {
   return (num >= 0) ? floor(num + 0.5) : ceil(num - 0.5);
 }
+#endif
 #endif
 
 /* resolve missing isinf() function for Solaris */

--- a/psycopg/config.h
+++ b/psycopg/config.h
@@ -129,14 +129,15 @@ static int pthread_mutex_init(pthread_mutex_t *mutex, void* fake)
 /* remove the inline keyword, since it doesn't work unless C++ file */
 #define inline
 
-/* Hmmm, MSVC doesn't have a isnan/isinf function, but has _isnan function */
+/* Hmmm, MSVC <2015 doesn't have a isnan/isinf function, but has _isnan function */
 #if defined (_MSC_VER)
+#if !defined(isnan)
 #define isnan(x) (_isnan(x))
 /* The following line was hacked together from simliar code by Bjorn Reese
  * in libxml2 code */
 #define isinf(x) ((_fpclass(x) == _FPCLASS_PINF) ? 1 \
 	: ((_fpclass(x) == _FPCLASS_NINF) ? -1 : 0))
-
+#endif
 #define strcasecmp(x, y) lstrcmpi(x, y)
 #endif
 #endif


### PR DESCRIPTION
Recently, Python 3.5 was released, which also changed the default compiler used on Windows to MSVC 2015. Psycopg2 did not yet compile under this version of MSVC.

The fixes are simple:

* `isnan` is a macro that MSVC did not define in older version, the code just assumed it wasn't present in all versions, fixed so that it only re-defines it when it is really not existent
* `round` is a function that MSVC did previously not define, now they do, fixed by checking for a specific version

I've never contributed to this project, so please let me know if you want to see things differently :)