### PR TITLE
Report libpq error code for errors with no message

### DIFF
--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -190,8 +190,9 @@ pq_raise(connectionObject *conn, cursorObject *curs, PGresult **pgres)
        raise and a meaningful message is better than an empty one.
        Note: it can happen without it being our error: see ticket #82 */
     if (err == NULL || err[0] == '\0') {
-        PyErr_SetString(DatabaseError,
-            "error with no message from the libpq");
+        PyErr_Format(DatabaseError,
+            "error code %s with no error message from libpq",
+            PQresStatus(pgres == NULL ? PQstatus(conn->pgconn) : PQresultStatus(*pgres)));
         return;
     }
 


### PR DESCRIPTION
Instead of:

    DatabaseError: error with no message from the libpq

raise a message like:

    DatabaseError: error code PGRES_COPY_BOTH with no error message from
    libpq

(In this particular case PGRES_COPY_BOTH isn't actually an error, but
psycopg2 doesn't understand it and should treat it that way.)

Fixes #352