### PR TITLE
New Insert_Values adapter

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -971,12 +971,12 @@ def register_composite(name, conn_or_curs, globally=False, factory=None):
 class Insert_Values(list):
     def __init__(self, list_of_tuples):
         assert isinstance(list_of_tuples, list), 'Insert_Values argument must be a list'
-        tuples_lenght = set()
+        tuples_length = set()
         for t in list_of_tuples:
             assert isinstance(t, tuple), 'The Insert_Values list elements must all be tuples'
-            tuples_lenght.add(len(t))
-        assert len(tuples_lenght) > 0, 'The Insert_Values List must not be empty'
-        assert len(tuples_lenght) == 1, 'All Insert_Values tuples must have the same length'
+            tuples_length.add(len(t))
+        assert len(tuples_length) > 0, 'The Insert_Values List must not be empty'
+        assert len(tuples_length) == 1, 'All Insert_Values tuples must have the same length'
         self._list_of_tuples = list_of_tuples
     def __str__(self):
         return str(self._list_of_tuples)
@@ -987,7 +987,6 @@ def adapt_insert_values(values):
 
 def register_insert_values():
     _ext.register_adapter(Insert_Values, adapt_insert_values)
-
 
 # expose the json adaptation stuff into the module
 from psycopg2._json import json, Json, register_json

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -968,6 +968,26 @@ def register_composite(name, conn_or_curs, globally=False, factory=None):
 
     return caster
 
+class Insert_Values(list):
+    def __init__(self, list_of_tuples):
+        assert isinstance(list_of_tuples, list), 'Insert_Values argument must be a list'
+        tuples_lenght = set()
+        for t in list_of_tuples:
+            assert isinstance(t, tuple), 'The Insert_Values list elements must all be tuples'
+            tuples_lenght.add(len(t))
+        assert len(tuples_lenght) > 0, 'The Insert_Values List must not be empty'
+        assert len(tuples_lenght) == 1, 'All Insert_Values tuples must have the same length'
+        self._list_of_tuples = list_of_tuples
+    def __str__(self):
+        return str(self._list_of_tuples)
+
+def adapt_insert_values(values):
+    l = [_A(t).getquoted() for t in values._list_of_tuples]
+    return _ext.AsIs(','.join(l))
+
+def register_insert_values():
+    _ext.register_adapter(Insert_Values, adapt_insert_values)
+
 
 # expose the json adaptation stuff into the module
 from psycopg2._json import json, Json, register_json


### PR DESCRIPTION
It is common to see people confused about how to insert multiple rows __at once__ using this SQL syntax

```sql
insert into t (a, b) values (1, 'a'), (2, 'b')
```

Often what is suggested for them is some form of messy string building. This is a cleaner suggestion to insert a list of tuples:

```python
data = [(1, 'a'), (2, 'b')]
records_list_template = ','.join(['%s' for t in data])
insert_query = 'insert into t (a, b) values {0}'.format(records_list_template)
cursor.execute(insert_query, data)
```

But it can be simpler by registering an adapter:

```python
from insert_values_adapter import Insert_Values, register_insert_values
register_insert_values()

data = [(1, 'a'), (2, 'b')]
insert_query = 'insert into t (a, b) values %s'

cursor.execute(insert_query, (Insert_Values(data),))
```

The `insert_values_adapter` module:

```python
from psycopg2 import extensions as _ext
from psycopg2.extensions import adapt as _A

class Insert_Values(list):
    def __init__(self, list_of_tuples):
        assert isinstance(list_of_tuples, list), 'Insert_Values argument must be a list'
        tuples_length = set()
        for t in list_of_tuples:
            assert isinstance(t, tuple), 'The Insert_Values list elements must all be tuples'
            tuples_length.add(len(t))
        assert len(tuples_length) > 0, 'The Insert_Values List must not be empty'
        assert len(tuples_length) == 1, 'All Insert_Values tuples must have the same length'
        self._list_of_tuples = list_of_tuples
    def __str__(self):
        return str(self._list_of_tuples)

def adapt_insert_values(values):
    l = [_A(t).getquoted() for t in values._list_of_tuples]
    return _ext.AsIs(','.join(l))

def register_insert_values():
    _ext.register_adapter(Insert_Values, adapt_insert_values)
```

So I propose a patch to `extras.py` including the code of the Class and functions in the above module