### PR TITLE
Add connection.quote_ident(str)

### DIFF
--- a/doc/src/connection.rst
+++ b/doc/src/connection.rst
@@ -582,6 +582,16 @@ The ``connection`` class
 
             .. __: http://www.postgresql.org/docs/current/static/libpq-status.html#LIBPQ-PQTRANSACTIONSTATUS
 
+    .. method:: quote_ident(str)
+    
+        Return quoted identifier according to PostgreSQL quoting rules.
+
+        Requires libpq >= 9.0.
+
+        .. seealso:: libpq docs for `PQescapeIdentifier()`__.
+
+            .. __: http://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQESCAPEIDENTIFIER
+
 
     .. index::
         pair: Protocol; Version

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1815,7 +1815,7 @@ cursor_setup(cursorObject *self, connectionObject *conn, const char *name)
     Dprintf("cursor_setup: parameters: name = %s, conn = %p", name, conn);
 
     if (name) {
-        if (!(self->name = psycopg_escape_identifier_easy(name, 0))) {
+        if (!(self->name = psycopg_escape_identifier(conn, name, 0))) {
             return -1;
         }
     }

--- a/psycopg/psycopg.h
+++ b/psycopg/psycopg.h
@@ -124,6 +124,7 @@ RAISES HIDDEN PyObject *psyco_set_error(PyObject *exc, cursorObject *curs, const
 HIDDEN char *psycopg_escape_string(connectionObject *conn,
               const char *from, Py_ssize_t len, char *to, Py_ssize_t *tolen);
 HIDDEN char *psycopg_escape_identifier_easy(const char *from, Py_ssize_t len);
+HIDDEN char *psycopg_escape_identifier(connectionObject *conn, const char *from, Py_ssize_t len);
 HIDDEN int psycopg_strdup(char **to, const char *from, Py_ssize_t len);
 HIDDEN int psycopg_is_text_file(PyObject *f);
 

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -23,7 +23,7 @@
 # License for more details.
 
 import sys
-from testutils import unittest, ConnectingTestCase
+from testutils import unittest, ConnectingTestCase, skip_before_libpq
 
 import psycopg2
 import psycopg2.extensions
@@ -163,6 +163,13 @@ class TestQuotedString(ConnectingTestCase):
         self.conn.set_client_encoding('utf_8')
         q.prepare(self.conn)
         self.assertEqual(q.encoding, 'utf_8')
+
+
+class TestQuotedIdentifier(ConnectingTestCase):
+    @skip_before_libpq(9, 0)
+    def test_identifier(self):
+        self.assertEqual(self.conn.quote_ident('blah-blah'), '"blah-blah"')
+        self.assertEqual(self.conn.quote_ident('quote"inside'), '"quote""inside"')
 
 
 def test_suite():


### PR DESCRIPTION
Also use PQescapeIdentifier to quote cursor name.

See #308 and #209.