### PR TITLE
Rework psycopg2.connect() interface.

### DIFF
--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -24,6 +24,28 @@ functionalities defined by the |DBAPI|_.
         >>> psycopg2.extensions.parse_dsn('dbname=test user=postgres password=secret')
         {'password': 'secret', 'user': 'postgres', 'dbname': 'test'}
 
+.. function:: make_dsn(**kwargs)
+
+    Wrap keyword parameters into a connection string, applying necessary
+    quoting and escaping any special characters (namely, single quote and
+    backslash).
+
+    Example (note the order of parameters in the resulting string is
+    arbitrary)::
+
+        >>> psycopg2.extensions.make_dsn(dbname='test', user='postgres', password='secret')
+        'user=postgres dbname=test password=secret'
+
+    As a special case, the *database* keyword is translated to *dbname*::
+
+        >>> psycopg2.extensions.make_dsn(database='test')
+        'dbname=test'
+
+    An example of quoting (using `print()` for clarity)::
+
+        >>> print(psycopg2.extensions.make_dsn(database='test', password="some\\thing ''special"))
+        password='some\\thing \'\'special' dbname=test
+
 .. class:: connection(dsn, async=False)
 
     Is the class usually returned by the `~psycopg2.connect()` function.

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -56,7 +56,8 @@ try:
 except ImportError:
     pass
 
-from psycopg2._psycopg import adapt, adapters, encodings, connection, cursor, lobject, Xid, libpq_version, parse_dsn, quote_ident
+from psycopg2._psycopg import adapt, adapters, encodings, connection, cursor, lobject, Xid, libpq_version
+from psycopg2._psycopg import parse_dsn, make_dsn, quote_ident
 from psycopg2._psycopg import string_types, binary_types, new_type, new_array_type, register_type
 from psycopg2._psycopg import ISQLQuote, Notify, Diagnostics, Column
 

--- a/psycopg/psycopg.h
+++ b/psycopg/psycopg.h
@@ -119,11 +119,17 @@ typedef struct cursorObject cursorObject;
 typedef struct connectionObject connectionObject;
 
 /* some utility functions */
+HIDDEN PyObject *psyco_parse_args(PyObject *self, PyObject *args, PyObject *kwargs);
+HIDDEN PyObject *psyco_parse_dsn(PyObject *self, PyObject *args, PyObject *kwargs);
+HIDDEN PyObject *psyco_make_dsn(PyObject *self, PyObject *args, PyObject *kwargs);
+
 RAISES HIDDEN PyObject *psyco_set_error(PyObject *exc, cursorObject *curs, const char *msg);
 
 HIDDEN char *psycopg_escape_string(connectionObject *conn,
               const char *from, Py_ssize_t len, char *to, Py_ssize_t *tolen);
 HIDDEN char *psycopg_escape_identifier_easy(const char *from, Py_ssize_t len);
+HIDDEN char *psycopg_escape_conninfo(const char *from, Py_ssize_t len);
+
 HIDDEN int psycopg_strdup(char **to, const char *from, Py_ssize_t len);
 HIDDEN int psycopg_is_text_file(PyObject *f);
 

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -70,24 +70,104 @@ HIDDEN PyObject *psyco_null = NULL;
 /* The type of the cursor.description items */
 HIDDEN PyObject *psyco_DescriptionType = NULL;
 
+
+/* finds a keyword or positional arg (pops it from kwargs if found there) */
+static PyObject *
+parse_arg(int pos, char *name, PyObject *defval, PyObject *args, PyObject *kwargs)
+{
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    PyObject *val = NULL;
+
+    if (kwargs && PyMapping_HasKeyString(kwargs, name)) {
+        val = PyMapping_GetItemString(kwargs, name);
+        Py_XINCREF(val);
+        PyMapping_DelItemString(kwargs, name); /* pop from the kwargs dict! */
+    }
+    if (nargs > pos) {
+        if (!val) {
+            val = PyTuple_GET_ITEM(args, pos);
+            Py_XINCREF(val);
+        } else {
+            PyErr_Format(PyExc_TypeError,
+                         "parse_args() got multiple values for keyword argument '%s'", name);
+            return NULL;
+        }
+    }
+    if (!val) {
+        val = defval;
+        Py_XINCREF(val);
+    }
+
+    return val;
+}
+
+
+#define psyco_parse_args_doc \
+"parse_args(...) -- parse connection parameters.\n\n" \
+"Return a tuple of (dsn, connection_factory, async)"
+
+PyObject *
+psyco_parse_args(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    PyObject *dsn = NULL;
+    PyObject *factory = NULL;
+    PyObject *async = NULL;
+    PyObject *res = NULL;
+
+    if (nargs > 3) {
+        PyErr_Format(PyExc_TypeError,
+                     "parse_args() takes at most 3 arguments (%d given)", (int)nargs);
+        goto exit;
+    }
+    /* parse and remove all keywords we know, so they are not interpreted as part of DSN */
+    if (!(dsn = parse_arg(0, "dsn", Py_None, args, kwargs))) { goto exit; }
+    if (!(factory = parse_arg(1, "connection_factory", Py_None,
+                              args, kwargs))) { goto exit; }
+    if (!(async = parse_arg(2, "async", Py_False, args, kwargs))) { goto exit; }
+
+    if (kwargs && PyMapping_Size(kwargs) > 0) {
+        if (dsn == Py_None) {
+            Py_DECREF(dsn);
+            if (!(dsn = psyco_make_dsn(NULL, NULL, kwargs))) { goto exit; }
+        } else {
+            PyErr_SetString(PyExc_TypeError, "both dsn and parameters given");
+            goto exit;
+        }
+    } else {
+        if (dsn == Py_None) {
+            PyErr_SetString(PyExc_TypeError, "missing dsn and no parameters");
+            goto exit;
+        }
+    }
+
+    res = PyTuple_Pack(3, dsn, factory, async);
+
+exit:
+    Py_XDECREF(dsn);
+    Py_XDECREF(factory);
+    Py_XDECREF(async);
+
+    return res;
+}
+
+
 /** connect module-level function **/
 #define psyco_connect_doc \
-"_connect(dsn, [connection_factory], [async]) -- New database connection.\n\n"
+"_connect(dsn, [connection_factory], [async], **kwargs) -- New database connection.\n\n"
 
 static PyObject *
 psyco_connect(PyObject *self, PyObject *args, PyObject *keywds)
 {
     PyObject *conn = NULL;
+    PyObject *tuple = NULL;
     PyObject *factory = NULL;
     const char *dsn = NULL;
     int async = 0;
 
-    static char *kwlist[] = {"dsn", "connection_factory", "async", NULL};
+    if (!(tuple = psyco_parse_args(self, args, keywds))) { goto exit; }
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|Oi", kwlist,
-                                     &dsn, &factory, &async)) {
-        return NULL;
-    }
+    if (!PyArg_ParseTuple(tuple, "s|Oi", &dsn, &factory, &async)) { goto exit; }
 
     Dprintf("psyco_connect: dsn = '%s', async = %d", dsn, async);
 
@@ -109,12 +189,16 @@ psyco_connect(PyObject *self, PyObject *args, PyObject *keywds)
         conn = PyObject_CallFunction(factory, "si", dsn, async);
     }
 
+exit:
+    Py_XDECREF(tuple);
+
     return conn;
 }
 
+
 #define psyco_parse_dsn_doc "parse_dsn(dsn) -> dict"
 
-static PyObject *
+PyObject *
 psyco_parse_dsn(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     char *err = NULL;
@@ -161,6 +245,114 @@ exit:
     PQconninfoFree(options);    /* safe on null */
     Py_XDECREF(dict);
     Py_XDECREF(dsn);
+
+    return res;
+}
+
+
+#define psyco_make_dsn_doc "make_dsn(**kwargs) -> str"
+
+PyObject *
+psyco_make_dsn(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    Py_ssize_t len, pos;
+    PyObject *res = NULL;
+    PyObject *key = NULL, *value = NULL;
+    PyObject *newkey, *newval;
+    PyObject *dict = NULL;
+    char *str = NULL, *p, *q;
+
+    if (args && (len = PyTuple_Size(args)) > 0) {
+        PyErr_Format(PyExc_TypeError, "make_dsn() takes no arguments (%d given)", (int)len);
+        goto exit;
+    }
+    if (kwargs == NULL) {
+        return Text_FromUTF8("");
+    }
+
+    /* iterate through kwargs, calculating the total resulting string
+       length and saving prepared key/values to a temp. dict */
+    if (!(dict = PyDict_New())) { goto exit; }
+
+    len = 0;
+    pos = 0;
+    while (PyDict_Next(kwargs, &pos, &key, &value)) {
+        if (value == NULL || value == Py_None) { continue; }
+
+        Py_INCREF(key); /* for ensure_bytes */
+        if (!(newkey = psycopg_ensure_bytes(key))) { goto exit; }
+
+        /* special handling of 'database' keyword */
+        if (strcmp(Bytes_AsString(newkey), "database") == 0) {
+            key = Bytes_FromString("dbname");
+            Py_DECREF(newkey);
+        } else {
+            key = newkey;
+        }
+
+        /* now transform the value */
+        if (Bytes_CheckExact(value)) {
+            Py_INCREF(value);
+        } else if (PyUnicode_CheckExact(value)) {
+            if (!(value = PyUnicode_AsUTF8String(value))) { goto exit; }
+        } else {
+            /* this could be port=5432, so we need to get the text representation */
+            if (!(value = PyObject_Str(value))) { goto exit; }
+            /* and still ensure it's bytes() (but no need to incref here) */
+            if (!(value = psycopg_ensure_bytes(value))) { goto exit; }
+        }
+
+        /* passing NULL for plen checks for NIL bytes in content and errors out */
+        if (Bytes_AsStringAndSize(value, &str, NULL) < 0) { goto exit; }
+        /* escape any special chars */
+        if (!(str = psycopg_escape_conninfo(str, 0))) { goto exit; }
+        if (!(newval = Bytes_FromString(str))) {
+            goto exit;
+        }
+        PyMem_Free(str);
+        str = NULL;
+        Py_DECREF(value);
+        value = newval;
+
+        /* finally put into the temp. dict */
+        if (PyDict_SetItem(dict, key, value) < 0) { goto exit; }
+
+        len += Bytes_GET_SIZE(key) + Bytes_GET_SIZE(value) + 2; /* =, space or NIL */
+
+        Py_DECREF(key);
+        Py_DECREF(value);
+    }
+    key = NULL;
+    value = NULL;
+
+    if (!(str = PyMem_Malloc(len))) {
+        PyErr_NoMemory();
+        goto exit;
+    }
+
+    p = str;
+    pos = 0;
+    while (PyDict_Next(dict, &pos, &newkey, &newval)) {
+        if (p != str) {
+            *(p++) = ' ';
+        }
+        if (Bytes_AsStringAndSize(newkey, &q, &len) < 0) { goto exit; }
+        strncpy(p, q, len);
+        p += len;
+        *(p++) = '=';
+        if (Bytes_AsStringAndSize(newval, &q, &len) < 0) { goto exit; }
+        strncpy(p, q, len);
+        p += len;
+    }
+    *p = '\0';
+
+    res = Text_FromUTF8AndSize(str, p - str);
+
+exit:
+    PyMem_Free(str);
+    Py_XDECREF(key);
+    Py_XDECREF(value);
+    Py_XDECREF(dict);
 
     return res;
 }
@@ -820,8 +1012,12 @@ error:
 static PyMethodDef psycopgMethods[] = {
     {"_connect",  (PyCFunction)psyco_connect,
      METH_VARARGS|METH_KEYWORDS, psyco_connect_doc},
+    {"parse_args",  (PyCFunction)psyco_parse_args,
+     METH_VARARGS|METH_KEYWORDS, psyco_parse_args_doc},
     {"parse_dsn",  (PyCFunction)psyco_parse_dsn,
      METH_VARARGS|METH_KEYWORDS, psyco_parse_dsn_doc},
+    {"make_dsn",  (PyCFunction)psyco_make_dsn,
+     METH_VARARGS|METH_KEYWORDS, psyco_make_dsn_doc},
     {"quote_ident", (PyCFunction)psyco_quote_ident,
      METH_VARARGS|METH_KEYWORDS, psyco_quote_ident_doc},
     {"adapt",  (PyCFunction)psyco_microprotocols_adapt,

--- a/psycopg/utils.c
+++ b/psycopg/utils.c
@@ -124,6 +124,50 @@ psycopg_escape_identifier_easy(const char *from, Py_ssize_t len)
     return rv;
 }
 
+char *
+psycopg_escape_conninfo(const char *from, Py_ssize_t len)
+{
+    char *rv = NULL;
+    const char *src;
+    const char *end;
+    char *dst;
+    int space = 0;
+
+    if (!len) { len = strlen(from); }
+    end = from + len;
+
+    if (!(rv = PyMem_Malloc(3 + 2 * len))) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    /* check for any whitespace or empty string */
+    if (from < end && *from) {
+        for (src = from; src < end && *src; ++src) {
+            if (isspace(*src)) {
+                space = 1;
+                break;
+            }
+        }
+    } else {
+        /* empty string: we should produce '' */
+        space = 1;
+    }
+
+    dst = rv;
+    if (space) { *(dst++) = '\''; }
+    /* scan and copy */
+    for (src = from; src < end && *src; ++src, ++dst) {
+        if (*src == '\'' || *src == '\\')
+            *(dst++) = '\\';
+        *dst = *src;
+    }
+    if (space) { *(dst++) = '\''; }
+    *dst = '\0';
+
+    return rv;
+}
+
 /* Duplicate a string.
  *
  * Allocate a new buffer on the Python heap containing the new string.


### PR DESCRIPTION
This might sound scary, but...  I have some good reasons to move the `psycopg2.connect()` logic to the C level.

1. (actually "0", but markdown is stupid :-p) This is meant to be 100% backwards compatible.  All tests pass with Python 2.7 and 3.4.
2. Adds new module function `make_dsn` that replaces the `join('%s=%s') / _param_escape` logic.
3. Adds new (undocumented) module function `parse_args` that is used in `_connect` implementation, and in `test_module` to capture the arguments.
4. The order of `dbname/user/host/port` after mapping to conninfo is not stable anymore so I had to replace some assertions of exact equality in tests.  Hope this is not a huge problem.
5. This is how I intend to use this new API to implement the `ReplicationConnection` class in C: https://github.com/zalando/psycopg2/commit/fbcf99ad070a3eae67c258d357ab86bda29793fd#diff-ae1fa330192a5b746297ae9317bbeae0R62
6. As you can see, both `parse_dsn` and `make_dsn` are utilized.  Currently, while this is not available yet I have to to duplicate the `_param_escape` logic in `extras.py`.

I've found it pity that the handy `PyArg_ParseTupleAndKeywords` can't cope with variable number of arguments, so I had to invent some magic in `psyco_parge_args()`.  Basically, it pops any keys it is aware of from kwargs, then passes the rest to `psyco_make_dsn()`.