### PR TITLE
A convenient context manager for connection pools

### DIFF
--- a/lib/pool.py
+++ b/lib/pool.py
@@ -123,7 +123,6 @@ class AbstractConnectionPool(object):
             del self._used[key]
             del self._rused[id(conn)]
 
-    @property
     @contextmanager
     def quick_cursor(self):
         """A ContextManager for quickly getting a cursor"""

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -26,6 +26,7 @@ This module implements thread-safe (and not) connection pools.
 
 import psycopg2
 import psycopg2.extensions as _ext
+from contextlib import contextmanager
 
 
 class PoolError(psycopg2.Error):
@@ -121,6 +122,14 @@ class AbstractConnectionPool(object):
         if not self.closed or key in self._used:
             del self._used[key]
             del self._rused[id(conn)]
+
+    @property
+    @contextmanager
+    def quick_cursor(self):
+        """A ContextManager for quickly getting a  cursor"""
+        with self.getconn() as conn, conn.cursor() as cur:
+                    yield cur
+        self.putconn(conn)
 
     def _closeall(self):
         """Close all connections.

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -126,10 +126,12 @@ class AbstractConnectionPool(object):
     @property
     @contextmanager
     def quick_cursor(self):
-        """A ContextManager for quickly getting a  cursor"""
-        with self.getconn() as conn, conn.cursor() as cur:
-                    yield cur
-        self.putconn(conn)
+        """A ContextManager for quickly getting a cursor"""
+        try:
+           with self.getconn() as conn, conn.cursor() as cur:
+              yield cur
+        finally:
+           self.putconn(conn)
 
     def _closeall(self):
         """Close all connections.


### PR DESCRIPTION
Based on the ideas presented in: https://github.com/psycopg/psycopg2/pull/17/files
A context manager for connection pools seems like a really useful feature.  My proposal is a convenience method on connection pool that will handle all the levels of context down to the cursor. i.e., usage would be:

<pre>
with my_pool.quick_cursor() as cur:
    cur.execute(prepared_query)
    results = cur.fetchall()
</pre>

This is roughly equivalent to:

<pre>
try:
    connection = my_pool.getconn()
    with connection as conn, conn.cursor as cur:
        cur.execute(prepared_query)
        results = cur.fetchall()
finally:
    my_pool.putconn(connection)
</pre>


Even if the pool was built into it's own context, the three depth of context is annoying, and this seems like a common enough use case that it's worth having an easy and simple way to do it.

This is my preferred method for improving the connection pool situation vis-a-vis context managers.  Combining the pool and connection context, but not the cursor might be preferable for adaptability, but I think for a lot of people this feature is a straightforward way to easily get all the functionality they want.
