### PR TITLE
Modify setup.py to support setuptools/wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,10 @@ import os
 import sys
 import re
 import subprocess
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils.sysconfig import get_python_inc
 from distutils.ccompiler import get_default_compiler


### PR DESCRIPTION
To support creation of whl files for PyPI, setuptools need to be imported
instead of distutils.  Created try/except case to fall back to integrated
distutils if setuptools is not installed.