### PR TITLE
Suggest installing psycopg2 in windows using pip

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -95,7 +95,15 @@ Install from a package
     pair: Install; Windows
 
 **Microsoft Windows**
-    Jason Erickson maintains a packaged `Windows port of Psycopg`__ with
+    There are two options to install a precompiled `psycopg2` package under windows:
+    
+    **Option 1:** Using `pip`__ (Included in python 2.7.9+ and python 3.4+) and a binary wheel package.  Launch windows' command prompt (`cmd.exe`) and execute the following command::
+    
+        pip install psycopg2
+    
+    .. __: https://pip.pypa.io/en/stable/installing/
+    
+    **Option 2:** Jason Erickson maintains a packaged `Windows port of Psycopg`__ with
     installation executable. Download. Double click. Done.
 
     .. __: http://www.stickpeople.com/projects/python/win-psycopg/


### PR DESCRIPTION
pip is becoming the standard method for installing python packages, and now binary wheels are a better and easier option for users:
https://github.com/psycopg/psycopg2/issues/368