### PR TITLE
Add Python 3 to supported Pythons list (documentation)

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -18,7 +18,7 @@ The current `!psycopg2` implementation supports:
     NOTE: keep consistent with setup.py and the /features/ page.
 
 - Python 2 versions from 2.5 to 2.7
-- Python 3 versions from 3.1 to 3.4
+- Python 3 versions from 3.1 to 3.5
 - PostgreSQL versions from 7.4 to 9.4
 
 .. _PostgreSQL: http://www.postgresql.org/


### PR DESCRIPTION
In my experience, psycopg2 operates quite well on Python 3.5. I'm assuming this is just an oversight, but if there are reasons that it's intentional, sorry for the noise :)