### PR TITLE
dont claim copyright for future years

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -42,9 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Psycopg'
-from datetime import date
-year = date.today().year
-copyright = u'2001-%s, Federico Di Gregorio, Daniele Varrazzo' % year
+copyright = u'2001-2016, Federico Di Gregorio, Daniele Varrazzo'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
otherwise, when building from unchanged source in 2018,
it would claim Copyright 2018
which is not true

Being able to reproduce identical output from identical input
is important to Linux distributions