### PR TITLE
Avoid a possible null deref, tz might be NULL.

### DIFF
--- a/psycopg/adapter_datetime.c
+++ b/psycopg/adapter_datetime.c
@@ -451,7 +451,7 @@ psyco_TimestampFromTicks(PyObject *self, PyObject *args)
         tz);
 
 exit:
-    Py_DECREF(tz);
+    Py_XDECREF(tz);
     Py_XDECREF(m);
     return res;
 }


### PR DESCRIPTION
Found by clang static analyzer