### PR TITLE
Explicitly link with libm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -583,6 +583,7 @@ ext.append(Extension("psycopg2._psycopg", sources,
                      define_macros=define_macros,
                      include_dirs=include_dirs,
                      depends=depends,
+                     libraries=['m'],
                      undef_macros=[]))
 
 # Compute the direct download url.


### PR DESCRIPTION
Without this, psycopg2 fails to compile on systems where "-lm" is not added by default.

Here is one of such examples, though discussion is in Russian:
http://forum.rosalab.ru/viewtopic.php?f=53&t=7272