### PR TITLE
add a __str__ method to NoneAdapter

### DIFF
--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -154,6 +154,9 @@ class NoneAdapter(object):
     def getquoted(self, _null=b("NULL")):
         return _null
 
+    def __str__(self):
+        return str(self.getquoted())
+
 
 def make_dsn(dsn=None, **kwargs):
     """Convert a set of keywords into a connection strings."""


### PR DESCRIPTION
I'm compiling SQLAlchemy queries and found that when I interpolate the bind parameters, NoneAdapter shows up as <psycopg2.extensions.NoneAdapter object at 0xad8f110> instead of the expected NULL.