### PR TITLE
Support for 'quote' and 'format' parameters to copy_from() 

### DIFF
--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1390,7 +1390,7 @@ psyco_curs_copy_from(cursorObject *self, PyObject *args, PyObject *kwargs)
         goto exit;
     }
     query_size = strlen(command) + strlen(table_name) + strlen(columnlist)
-        + strlen(quoted_delimiter) + strlen(quoted_null) strlen(quoted_quote) + 1;
+        + strlen(quoted_delimiter) + strlen(quoted_null) + strlen(quoted_quote) + 1;
     if (!(query = PyMem_New(char, query_size))) {
         PyErr_NoMemory();
         goto exit;

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1343,7 +1343,7 @@ psyco_curs_copy_from(cursorObject *self, PyObject *args, PyObject *kwargs)
 
     const char *sep = "\t";
     const char *null = "\\N";
-    const char *quote = '"';
+    const char *quote = "\"";
 
     const char *command =
         "COPY %s%s FROM stdin WITH DELIMITER AS %s NULL AS %s QUOTE AS %s CSV";

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1312,7 +1312,7 @@ exit:
 /* extension: copy_from - implements COPY FROM */
 
 #define psyco_curs_copy_from_doc \
-"copy_from(file, table, sep='\\t', null='\\\\N', size=8192, columns=None) -- Copy table from file."
+"copy_from(file, table, sep='\\t', null='\\\\N', size=8192, columns=None, quote='\"', format='TXT') -- Copy table from file."
 
 STEALS(1) static int
 _psyco_curs_has_read_check(PyObject *o, PyObject **var)

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1343,7 +1343,7 @@ psyco_curs_copy_from(cursorObject *self, PyObject *args, PyObject *kwargs)
 
     const char *sep = "\t";
     const char *null = "\\N";
-    const char *quote = "'";
+    const char *quote = '"';
 
     const char *command =
         "COPY %s%s FROM stdin WITH DELIMITER AS %s NULL AS %s QUOTE AS %s CSV";

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1346,7 +1346,7 @@ psyco_curs_copy_from(cursorObject *self, PyObject *args, PyObject *kwargs)
     const char *quote = "'";
 
     const char *command =
-        "COPY %s%s FROM stdin WITH DELIMITER AS %s NULL AS %s FORMAT AS CSV QUOTE AS %s";
+        "COPY %s%s FROM stdin WITH DELIMITER AS %s NULL AS %s QUOTE AS %s CSV";
 
     Py_ssize_t query_size;
     char *query = NULL;

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -1361,7 +1361,7 @@ psyco_curs_copy_from(cursorObject *self, PyObject *args, PyObject *kwargs)
     PyObject *file, *columns = NULL, *res = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-        "O&s|ssnO", kwlist,
+        "O&s|ssnOss", kwlist,
         _psyco_curs_has_read_check, &file, &table_name, &sep, &null, &bufsize,
         &columns, &quote, &format))
     {

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -217,6 +217,29 @@ class CopyTests(ConnectingTestCase):
         curs.execute("select data from tcopy;")
         self.assertEqual(curs.fetchone()[0], abin)
 
+    def _copy_from_csv(self, curs, nrecs, srec, copykw, mock_columns_enclosed_by):
+
+        f = StringIO()
+        for i, c in izip(xrange(nrecs), cycle(string.ascii_letters)):
+            l = c * srec
+            # Enclose '{1}' and '{2}' in the quote char '{0}' (Defaults to '"')
+            f.write("%s,%s%s%s\n" % (i,mock_columns_enclosed_by,l,mock_columns_enclosed_by))
+
+        f.seek(0)
+        copykw['format'] = 'CSV'  
+        
+        copykw['sep'] = ","
+        curs.copy_from(MinimalRead(f), "tcopy", **copykw)
+
+        curs.execute("select count(*) from tcopy")
+        self.assertEqual(nrecs, curs.fetchone()[0])
+
+        curs.execute("select data from tcopy where id < %s order by id",
+                (len(string.ascii_letters),))
+        for i, (l,) in enumerate(curs):
+            self.assertEqual(l, string.ascii_letters[i] * srec)
+
+
     def _copy_from(self, curs, nrecs, srec, copykw):
         f = StringIO()
         for i, c in izip(xrange(nrecs), cycle(string.ascii_letters)):
@@ -366,7 +389,29 @@ conn.close()
         curs.execute("insert into tcopy values (10, 'hi')")
         self.assertRaises(ZeroDivisionError,
             curs.copy_to, BrokenWrite(), "tcopy")
-
+    def test_copy_from_csv(self):
+        curs = self.conn.cursor()
+        try:
+            # 'Quote' should default to '"'
+            self._copy_from_csv(curs, nrecs=1024, srec=10*1024, copykw={}, mock_columns_enclosed_by='"')
+        finally:
+            curs.close()
+    def test_copy_from_csv_specify_column_enclosure(self):
+        curs = self.conn.cursor()
+        try:
+            self._copy_from_csv(curs, nrecs=1024, srec=10*1024, copykw={'quote': "'"}, mock_columns_enclosed_by="'")
+        finally:
+            curs.close()
+    def test_copy_txt_and_set_quote(self):
+        # this shouldn't return an error...
+        # b/c format = 'TXT' by default, and we do not
+        # override this default here, quote does not get included
+        # in the COPY ... FROM ... command.
+        curs = self.conn.cursor()
+        try:
+            self._copy_from(curs, nrecs=1024, srec=10*1024, copykw={'quote': "'"})
+        finally:
+            curs.close()
 
 decorate_all_tests(CopyTests, skip_copy_if_green)
 


### PR DESCRIPTION
**Support added for 'quote' and 'format' parameters to the COPY FROM command.**

1. Added 'format' parameter to "copy_from()". Expects a string: either "TXT" or "CSV" (default is "TXT"). This allows the 'quote' parameter to be set (see next bullet).
2. Added 'quote' parameter to "copy_from()". Expects a single character, defaults to '"'. This allows columns of data to be enclosed in this character, removing the need to escape various characters within the string.
  - For instance, the row **143,Hello, World,10002** would get interpreted as 4 columns, separated by commas, when in reality you would want only 3 comma separated values, with "Hello, World" in quotes (**123,"Hello, World",10002**). This 'quote' parameter allows copy_from() to load .csv files in the proper format defined [here in RFC4180](https://tools.ietf.org/html/rfc4180)
  - _If **quote** is set, and **format** is set to "TXT", the parameter 'quote' will be ignored when compiling the COPY FROM command. (because the native COPY FROM does not support 'quote' in TXT format)_
3. Test coverage added for 3 cases:
  - Loading a standard csv (double-quote enclosed strings)
  - Loading a csv with single-quote enclosed strings
  - Passing **quote="'"** when **format="TXT"** (expects no error) 

```python
# Basic case to load a csv into a table
with open("foobar.csv", "r") as fp:
    cur = self.conn.cursor()
    cur.copy_from(fp, table_name, null="NULL", sep=",", format="CSV")

```

