### PR TITLE
fix wait_select sample to be `extras` not `extensions`

### DIFF
--- a/doc/src/faq.rst
+++ b/doc/src/faq.rst
@@ -241,7 +241,7 @@ How do I interrupt a long-running query in an interactive shell?
 
     .. code-block:: pycon
 
-        >>> psycopg2.extensions.set_wait_callback(psycopg2.extensions.wait_select)
+        >>> psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
         >>> cnn = psycopg2.connect('')
         >>> cur = cnn.cursor()
         >>> cur.execute("select pg_sleep(10)")


### PR DESCRIPTION
Fix faq `wait_select` sample to be `extras` not `extensions`
