### PR TITLE
Fixed version regexp to match "10devel"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -417,10 +417,12 @@ class psycopg_build_ext(build_ext):
                 pgversion = "7.4.0"
 
             verre = re.compile(
-                r"(\d+)\.(\d+)(?:(?:\.(\d+))|(devel|(alpha|beta|rc)\d+))")
+                r"(\d+)(?:\.(\d+))?(?:(?:\.(\d+))|(devel|(?:alpha|beta|rc)\d+))?")
             m = verre.match(pgversion)
             if m:
                 pgmajor, pgminor, pgpatch = m.group(1, 2, 3)
+                if pgminor is None or not pgminor.isdigit():
+                    pgminor = 0
                 if pgpatch is None or not pgpatch.isdigit():
                     pgpatch = 0
                 pgmajor = int(pgmajor)


### PR DESCRIPTION
Also normalized the result and made sure that if PostgreSQL ever starts
using just integer version numbers (as in "10") everything still works.