### PR TITLE
TST: fix PendingDeprecationWarning: Please use assertTrue instead

### DIFF
--- a/tests/dbapi20.py
+++ b/tests/dbapi20.py
@@ -171,7 +171,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             # Must exist
             threadsafety = self.driver.threadsafety
             # Must be a valid value
-            self.failUnless(threadsafety in (0,1,2,3))
+            self.assertTrue(threadsafety in (0,1,2,3))
         except AttributeError:
             self.fail("Driver doesn't define threadsafety")
 
@@ -180,7 +180,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             # Must exist
             paramstyle = self.driver.paramstyle
             # Must be a valid value
-            self.failUnless(paramstyle in (
+            self.assertTrue(paramstyle in (
                 'qmark','numeric','named','format','pyformat'
                 ))
         except AttributeError:
@@ -190,31 +190,31 @@ class DatabaseAPI20Test(unittest.TestCase):
         # Make sure required exceptions exist, and are in the
         # defined hierarchy.
         if sys.version[0] == '3': #under Python 3 StardardError no longer exists
-            self.failUnless(issubclass(self.driver.Warning,Exception))
-            self.failUnless(issubclass(self.driver.Error,Exception))
+            self.assertTrue(issubclass(self.driver.Warning,Exception))
+            self.assertTrue(issubclass(self.driver.Error,Exception))
         else:
-            self.failUnless(issubclass(self.driver.Warning,StandardError))
-            self.failUnless(issubclass(self.driver.Error,StandardError))
+            self.assertTrue(issubclass(self.driver.Warning,StandardError))
+            self.assertTrue(issubclass(self.driver.Error,StandardError))
 
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.InterfaceError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.DatabaseError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.OperationalError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.IntegrityError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.InternalError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.ProgrammingError,self.driver.Error)
             )
-        self.failUnless(
+        self.assertTrue(
             issubclass(self.driver.NotSupportedError,self.driver.Error)
             )
 
@@ -227,15 +227,15 @@ class DatabaseAPI20Test(unittest.TestCase):
         # by default.
         con = self._connect()
         drv = self.driver
-        self.failUnless(con.Warning is drv.Warning)
-        self.failUnless(con.Error is drv.Error)
-        self.failUnless(con.InterfaceError is drv.InterfaceError)
-        self.failUnless(con.DatabaseError is drv.DatabaseError)
-        self.failUnless(con.OperationalError is drv.OperationalError)
-        self.failUnless(con.IntegrityError is drv.IntegrityError)
-        self.failUnless(con.InternalError is drv.InternalError)
-        self.failUnless(con.ProgrammingError is drv.ProgrammingError)
-        self.failUnless(con.NotSupportedError is drv.NotSupportedError)
+        self.assertTrue(con.Warning is drv.Warning)
+        self.assertTrue(con.Error is drv.Error)
+        self.assertTrue(con.InterfaceError is drv.InterfaceError)
+        self.assertTrue(con.DatabaseError is drv.DatabaseError)
+        self.assertTrue(con.OperationalError is drv.OperationalError)
+        self.assertTrue(con.IntegrityError is drv.IntegrityError)
+        self.assertTrue(con.InternalError is drv.InternalError)
+        self.assertTrue(con.ProgrammingError is drv.ProgrammingError)
+        self.assertTrue(con.NotSupportedError is drv.NotSupportedError)
 
 
     def test_commit(self):
@@ -327,12 +327,12 @@ class DatabaseAPI20Test(unittest.TestCase):
             cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
                 self.table_prefix
                 ))
-            self.failUnless(cur.rowcount in (-1,1),
+            self.assertTrue(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number or rows inserted, or '
                 'set to -1 after executing an insert statement'
                 )
             cur.execute("select name from %sbooze" % self.table_prefix)
-            self.failUnless(cur.rowcount in (-1,1),
+            self.assertTrue(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number of rows returned, or '
                 'set to -1 after executing a select statement'
                 )
@@ -397,7 +397,7 @@ class DatabaseAPI20Test(unittest.TestCase):
         cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
             self.table_prefix
             ))
-        self.failUnless(cur.rowcount in (-1,1))
+        self.assertTrue(cur.rowcount in (-1,1))
 
         if self.driver.paramstyle == 'qmark':
             cur.execute(
@@ -426,7 +426,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 )
         else:
             self.fail('Invalid paramstyle')
-        self.failUnless(cur.rowcount in (-1,1))
+        self.assertTrue(cur.rowcount in (-1,1))
 
         cur.execute('select name from %sbooze' % self.table_prefix)
         res = cur.fetchall()
@@ -478,7 +478,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                     )
             else:
                 self.fail('Unknown paramstyle')
-            self.failUnless(cur.rowcount in (-1,2),
+            self.assertTrue(cur.rowcount in (-1,2),
                 'insert using cursor.executemany set cursor.rowcount to '
                 'incorrect value %r' % cur.rowcount
                 )
@@ -513,7 +513,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchone should return None if a query retrieves '
                 'no rows'
                 )
-            self.failUnless(cur.rowcount in (-1,0))
+            self.assertTrue(cur.rowcount in (-1,0))
 
             # cursor.fetchone should raise an Error if called after
             # executing a query that cannot return rows
@@ -533,7 +533,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.assertEqual(cur.fetchone(),None,
                 'cursor.fetchone should return None if no more rows available'
                 )
-            self.failUnless(cur.rowcount in (-1,1))
+            self.assertTrue(cur.rowcount in (-1,1))
         finally:
             con.close()
 
@@ -589,7 +589,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchmany should return an empty sequence after '
                 'results are exhausted'
             )
-            self.failUnless(cur.rowcount in (-1,6))
+            self.assertTrue(cur.rowcount in (-1,6))
 
             # Same as above, using cursor.arraysize
             cur.arraysize=4
@@ -602,12 +602,12 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.assertEqual(len(r),2)
             r = cur.fetchmany() # Should be an empty sequence
             self.assertEqual(len(r),0)
-            self.failUnless(cur.rowcount in (-1,6))
+            self.assertTrue(cur.rowcount in (-1,6))
 
             cur.arraysize=6
             cur.execute('select name from %sbooze' % self.table_prefix)
             rows = cur.fetchmany() # Should get all rows
-            self.failUnless(cur.rowcount in (-1,6))
+            self.assertTrue(cur.rowcount in (-1,6))
             self.assertEqual(len(rows),6)
             self.assertEqual(len(rows),6)
             rows = [r[0] for r in rows]
@@ -624,7 +624,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchmany should return an empty sequence if '
                 'called after the whole result set has been fetched'
                 )
-            self.failUnless(cur.rowcount in (-1,6))
+            self.assertTrue(cur.rowcount in (-1,6))
 
             self.executeDDL2(cur)
             cur.execute('select name from %sbarflys' % self.table_prefix)
@@ -633,7 +633,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchmany should return an empty sequence if '
                 'query retrieved no rows'
                 )
-            self.failUnless(cur.rowcount in (-1,0))
+            self.assertTrue(cur.rowcount in (-1,0))
 
         finally:
             con.close()
@@ -657,7 +657,7 @@ class DatabaseAPI20Test(unittest.TestCase):
 
             cur.execute('select name from %sbooze' % self.table_prefix)
             rows = cur.fetchall()
-            self.failUnless(cur.rowcount in (-1,len(self.samples)))
+            self.assertTrue(cur.rowcount in (-1,len(self.samples)))
             self.assertEqual(len(rows),len(self.samples),
                 'cursor.fetchall did not retrieve all rows'
                 )
@@ -673,12 +673,12 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchall should return an empty list if called '
                 'after the whole result set has been fetched'
                 )
-            self.failUnless(cur.rowcount in (-1,len(self.samples)))
+            self.assertTrue(cur.rowcount in (-1,len(self.samples)))
 
             self.executeDDL2(cur)
             cur.execute('select name from %sbarflys' % self.table_prefix)
             rows = cur.fetchall()
-            self.failUnless(cur.rowcount in (-1,0))
+            self.assertTrue(cur.rowcount in (-1,0))
             self.assertEqual(len(rows),0,
                 'cursor.fetchall should return an empty list if '
                 'a select query returns no rows'
@@ -700,7 +700,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             rows23 = cur.fetchmany(2)
             rows4  = cur.fetchone()
             rows56 = cur.fetchall()
-            self.failUnless(cur.rowcount in (-1,6))
+            self.assertTrue(cur.rowcount in (-1,6))
             self.assertEqual(len(rows23),2,
                 'fetchmany returned incorrect number of rows'
                 )
@@ -777,7 +777,7 @@ class DatabaseAPI20Test(unittest.TestCase):
         con = self._connect()
         try:
             cur = con.cursor()
-            self.failUnless(hasattr(cur,'arraysize'),
+            self.assertTrue(hasattr(cur,'arraysize'),
                 'cursor.arraysize must be defined'
                 )
         finally:
@@ -846,27 +846,27 @@ class DatabaseAPI20Test(unittest.TestCase):
         b = self.driver.Binary(str2bytes(''))
 
     def test_STRING(self):
-        self.failUnless(hasattr(self.driver,'STRING'),
+        self.assertTrue(hasattr(self.driver,'STRING'),
             'module.STRING must be defined'
             )
 
     def test_BINARY(self):
-        self.failUnless(hasattr(self.driver,'BINARY'),
+        self.assertTrue(hasattr(self.driver,'BINARY'),
             'module.BINARY must be defined.'
             )
 
     def test_NUMBER(self):
-        self.failUnless(hasattr(self.driver,'NUMBER'),
+        self.assertTrue(hasattr(self.driver,'NUMBER'),
             'module.NUMBER must be defined.'
             )
 
     def test_DATETIME(self):
-        self.failUnless(hasattr(self.driver,'DATETIME'),
+        self.assertTrue(hasattr(self.driver,'DATETIME'),
             'module.DATETIME must be defined.'
             )
 
     def test_ROWID(self):
-        self.failUnless(hasattr(self.driver,'ROWID'),
+        self.assertTrue(hasattr(self.driver,'ROWID'),
             'module.ROWID must be defined.'
             )
 


### PR DESCRIPTION
Fixes the following test errors on Python 2.7, Windows:
```
======================================================================
ERROR: test_BINARY (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 855, in test_BINARY
    'module.BINARY must be defined.'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_DATETIME (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 865, in test_DATETIME
    'module.DATETIME must be defined.'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_Exceptions (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 196, in test_Exceptions
    self.failUnless(issubclass(self.driver.Warning,StandardError))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_ExceptionsAsConnectionAttributes (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 230, in test_ExceptionsAsConnectionAttributes
    self.failUnless(con.Warning is drv.Warning)
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_NUMBER (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 860, in test_NUMBER
    'module.NUMBER must be defined.'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_ROWID (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 870, in test_ROWID
    'module.ROWID must be defined.'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_STRING (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 850, in test_STRING
    'module.STRING must be defined'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_arraysize (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 781, in test_arraysize
    'cursor.arraysize must be defined'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_execute (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 391, in test_execute
    self._paraminsert(cur)
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 400, in _paraminsert
    self.failUnless(cur.rowcount in (-1,1))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_executemany (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 483, in test_executemany
    'incorrect value %r' % cur.rowcount
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_fetchall (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 660, in test_fetchall
    self.failUnless(cur.rowcount in (-1,len(self.samples)))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_fetchmany (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 592, in test_fetchmany
    self.failUnless(cur.rowcount in (-1,6))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_fetchone (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 516, in test_fetchone
    self.failUnless(cur.rowcount in (-1,0))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_mixedfetch (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 703, in test_mixedfetch
    self.failUnless(cur.rowcount in (-1,6))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_paramstyle (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 184, in test_paramstyle
    'qmark','numeric','named','format','pyformat'
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_rowcount (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 331, in test_rowcount
    'cursor.rowcount should == number or rows inserted, or '
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_setinputsizes (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 791, in test_setinputsizes
    self._paraminsert(cur) # Make sure cursor still works
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 400, in _paraminsert
    self.failUnless(cur.rowcount in (-1,1))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_setoutputsize_basic (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 802, in test_setoutputsize_basic
    self._paraminsert(cur) # Make sure the cursor still works
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 400, in _paraminsert
    self.failUnless(cur.rowcount in (-1,1))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

======================================================================
ERROR: test_threadsafety (psycopg2.tests.test_psycopg2_dbapi20.Psycopg2Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\psycopg2\tests\dbapi20.py", line 174, in test_threadsafety
    self.failUnless(threadsafety in (0,1,2,3))
  File "X:\Python27\lib\unittest\case.py", line 611, in deprecated_func
    PendingDeprecationWarning, 2)
PendingDeprecationWarning: Please use assertTrue instead.

----------------------------------------------------------------------
Ran 640 tests in 30.625s

FAILED (errors=19, skipped=70)
```