### PR TITLE
Document that executemany() is not logged with LoggingConnection

### DIFF
--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -136,6 +136,11 @@ Logging cursor
 .. autoclass:: LoggingCursor
 
 
+.. note::
+
+    Queries that are executed with `cursor.executemany()` are not logged.
+
+
 .. autoclass:: MinTimeLoggingConnection
     :members: initialize,filter
 


### PR DESCRIPTION
fixes #546 