### PR TITLE
Make dbapi_extension.py compatible with Sphinx 1.6

### DIFF
--- a/doc/src/tools/lib/dbapi_extension.py
+++ b/doc/src/tools/lib/dbapi_extension.py
@@ -12,7 +12,7 @@
 from docutils import nodes
 
 from sphinx.locale import _
-from sphinx.util.compat import Directive, make_admonition
+from docutils.parsers.rst import Directive
 
 class extension_node(nodes.Admonition, nodes.Element): pass
 
@@ -29,12 +29,11 @@ class Extension(Directive):
     option_spec = {}
 
     def run(self):
-        nodes = make_admonition(extension_node,
-                self.name, [_('DB API extension')], self.options,
-                self.content, self.lineno, self.content_offset,
-                self.block_text, self.state, self.state_machine)
-        nodes[0]['classes'].append('dbapi-extension')
-        return nodes
+        node = extension_node('\n'.join(self.content))
+        node += nodes.title(_('DB API extension'), _('DB API extension'))
+        self.state.nested_parse(self.content, self.content_offset, node)
+        node['classes'].append('dbapi-extension')
+        return [node]
 
 
 def visit_extension_node(self, node):


### PR DESCRIPTION
In sphinx-doc/sphinx@1a821b89e9952fc2, the deprecated `make_admonition()` function was removed.

This pull request updates the code to use the modern API instead. Also `Directive` is imported from `docutils.parsers.rst`, as import from `sphinx.util.compat` is deprecated since sphinx-doc/sphinx@2df0bb8d03d05fe7.