### PR TITLE
Emulate timeradd and timersub on Solaris

### DIFF
--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -52,6 +52,10 @@
 #include "win32_support.h"
 #endif
 
+#if defined(__sun) && defined(__SVR4)
+#include "solaris_support.h"
+#endif
+
 extern HIDDEN PyObject *psyco_DescriptionType;
 extern HIDDEN const char *srv_isolevels[];
 extern HIDDEN const char *srv_readonly[];

--- a/psycopg/solaris_support.c
+++ b/psycopg/solaris_support.c
@@ -1,0 +1,54 @@
+/* solaris_support.c - emulate functions missing on Solaris
+ *
+ * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ *
+ * This file is part of psycopg.
+ *
+ * psycopg2 is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link this program with the OpenSSL library (or with
+ * modified versions of OpenSSL that use the same license as OpenSSL),
+ * and distribute linked combinations including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects for
+ * all of the code used other than OpenSSL.
+ *
+ * psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+
+#define PSYCOPG_MODULE
+#include "psycopg/psycopg.h"
+#include "psycopg/solaris_support.h"
+
+#if defined(__sun) && defined(__SVR4)
+/* timeradd is missing on Solaris */
+void
+timeradd(struct timeval *a, struct timeval *b, struct timeval *c)
+{
+    c->tv_sec = a->tv_sec + b->tv_sec;
+    c->tv_usec = a->tv_usec + b->tv_usec;
+    if (c->tv_usec >= 1000000) {
+        c->tv_usec -= 1000000;
+        c->tv_sec += 1;
+    }
+}
+
+/* timersub is missing on Solaris */
+void
+timersub(struct timeval *a, struct timeval *b, struct timeval *c)
+{
+    c->tv_sec = a->tv_sec - b->tv_sec;
+    c->tv_usec = a->tv_usec - b->tv_usec;
+    if (c->tv_usec < 0) {
+        c->tv_usec += 1000000;
+        c->tv_sec -= 1;
+    }
+}
+#endif /* defined(__sun) && defined(__SVR4) */

--- a/psycopg/solaris_support.h
+++ b/psycopg/solaris_support.h
@@ -1,0 +1,37 @@
+/* solaris_support.h - definitions for solaris_support.c
+ *
+ * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ *
+ * This file is part of psycopg.
+ *
+ * psycopg2 is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link this program with the OpenSSL library (or with
+ * modified versions of OpenSSL that use the same license as OpenSSL),
+ * and distribute linked combinations including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects for
+ * all of the code used other than OpenSSL.
+ *
+ * psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+#ifndef PSYCOPG_SOLARIS_SUPPORT_H
+#define PSYCOPG_SOLARIS_SUPPORT_H
+
+#include "psycopg/config.h"
+
+#if defined(__sun) && defined(__SVR4)
+#include <sys/time.h>
+
+extern HIDDEN void timeradd(struct timeval *a, struct timeval *b, struct timeval *c);
+extern HIDDEN void timersub(struct timeval *a, struct timeval *b, struct timeval *c);
+#endif
+
+#endif /* !defined(PSYCOPG_SOLARIS_SUPPORT_H) */

--- a/setup.py
+++ b/setup.py
@@ -480,7 +480,7 @@ data_files = []
 sources = [
     'psycopgmodule.c',
     'green.c', 'pqpath.c', 'utils.c', 'bytes_format.c',
-    'libpq_support.c', 'win32_support.c',
+    'libpq_support.c', 'win32_support.c', 'solaris_support.c',
 
     'connection_int.c', 'connection_type.c',
     'cursor_int.c', 'cursor_type.c',


### PR DESCRIPTION
Solaris does not have timeradd and timersub. Add solaris_support.c which
provides emulated versions of them on Solaris.