### PR TITLE
Patch for issue #609 for MinTimeLoggingConnection

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -455,6 +455,8 @@ class MinTimeLoggingConnection(LoggingConnection):
     def filter(self, msg, curs):
         t = (_time.time() - curs.timestamp) * 1000
         if t > self._mintime:
+            if _sys.version_info[0] >= 3 and isinstance(msg, bytes):
+                msg = msg.decode(_ext.encodings[self.encoding], 'replace')
             return msg + _os.linesep + "  (execution time: %d ms)" % t
 
     def cursor(self, *args, **kwargs):


### PR DESCRIPTION
On Python3 MinTimeLoggingConnection raises an exception as it tries to
mix strings and bytes. Fixes #609