### PR TITLE
Use modern except syntax throughout project

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -363,7 +363,7 @@ class NamedTupleCursor(_cursor):
 
     try:
         from collections import namedtuple
-    except ImportError, _exc:
+    except ImportError as _exc:
         def _make_nt(self):
             raise self._exc
     else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -65,7 +65,7 @@ def test_suite():
     import psycopg2
     try:
         cnn = psycopg2.connect(dsn)
-    except Exception, e:
+    except Exception as e:
         print "Failed connection to test db:", e.__class__.__name__, e
         print "Please set env vars 'PSYCOPG2_TESTDB*' to valid values."
         sys.exit(1)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -444,7 +444,7 @@ class AsyncTests(ConnectingTestCase):
         try:
             cnn = psycopg2.connect('dbname=thisdatabasedoesntexist', async_=True)
             self.wait(cnn)
-        except psycopg2.Error, e:
+        except psycopg2.Error as e:
             self.assertNotEqual(str(e), "asynchronous connection failed",
                 "connection error reason lost")
         else:

--- a/tests/test_async_keyword.py
+++ b/tests/test_async_keyword.py
@@ -81,7 +81,7 @@ class AsyncTests(ConnectingTestCase):
         try:
             cnn = psycopg2.connect('dbname=thisdatabasedoesntexist', async=True)
             self.wait(cnn)
-        except psycopg2.Error, e:
+        except psycopg2.Error as e:
             self.assertNotEqual(str(e), "asynchronous connection failed",
                 "connection error reason lost")
         else:

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -63,7 +63,7 @@ class CancelTests(ConnectingTestCase):
                 conn.rollback()
                 cur.execute("select 1")
                 self.assertEqual(cur.fetchall(), [(1, )])
-            except Exception, e:
+            except Exception as e:
                 errors.append(e)
                 raise
 
@@ -71,7 +71,7 @@ class CancelTests(ConnectingTestCase):
             cur = conn.cursor()
             try:
                 conn.cancel()
-            except Exception, e:
+            except Exception as e:
                 errors.append(e)
                 raise
             del cur

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -358,7 +358,7 @@ class ParseDsnTestCase(ConnectingTestCase):
         try:
             # unterminated quote after dbname:
             ext.parse_dsn("dbname='test 2 user=tester password=secret")
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             raised = True
             self.assertTrue(str(e).find('secret') < 0,
                             "DSN was not exposed in error message")
@@ -376,7 +376,7 @@ class ParseDsnTestCase(ConnectingTestCase):
         try:
             # extra '=' after port value
             ext.parse_dsn(dsn='postgresql://tester:secret@/test?port=1111=x')
-        except psycopg2.ProgrammingError, e:
+        except psycopg2.ProgrammingError as e:
             raised = True
             self.assertTrue(str(e).find('secret') < 0,
                             "URI was not exposed in error message")

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -364,7 +364,7 @@ conn.close()
         #     curs.copy_from, BrokenRead(), "tcopy")
         try:
             curs.copy_from(BrokenRead(), "tcopy")
-        except Exception, e:
+        except Exception as e:
             self.assert_('ZeroDivisionError' in str(e))
 
     def test_copy_to_propagate_error(self):

--- a/tests/test_errcodes.py
+++ b/tests/test_errcodes.py
@@ -48,7 +48,7 @@ class ErrocodeTests(ConnectingTestCase):
         def f(pg_code='40001'):
             try:
                 errorcodes.lookup(pg_code)
-            except Exception, e:
+            except Exception as e:
                 errs.append(e)
 
         for __ in xrange(MAX_CYCLES):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -152,7 +152,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.execute("select * from nonexist")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
 
         self.assertEqual(e.pgcode, '42P01')
@@ -163,7 +163,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.execute("select * from nonexist")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
 
         diag = e.diag
@@ -182,7 +182,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.execute("select * from nonexist")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
 
         self.assertEqual(e.diag.sqlstate, '42P01')
@@ -196,7 +196,7 @@ class ExceptionsTestCase(ConnectingTestCase):
             cur = self.conn.cursor()
             try:
                 cur.execute("select * from nonexist")
-            except psycopg2.Error, exc:
+            except psycopg2.Error as exc:
                 return cur, exc
 
         cur, e = tmp()
@@ -221,7 +221,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.copy_to(f, 'nonexist')
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             diag = exc.diag
 
         self.assertEqual(diag.sqlstate, '42P01')
@@ -230,14 +230,14 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.execute("l'acqua e' poca e 'a papera nun galleggia")
-        except Exception, exc:
+        except Exception as exc:
             diag1 = exc.diag
 
         self.conn.rollback()
 
         try:
             cur.execute("select level from water where ducks > 1")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             diag2 = exc.diag
 
         self.assertEqual(diag1.sqlstate, '42601')
@@ -254,7 +254,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur.execute("insert into test_deferred values (1,2)")
         try:
             self.conn.commit()
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
         self.assertEqual(e.diag.sqlstate, '23503')
 
@@ -267,7 +267,7 @@ class ExceptionsTestCase(ConnectingTestCase):
             )""")
         try:
             cur.execute("insert into test_exc values(2)")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
         self.assertEqual(e.pgcode, '23514')
         self.assertEqual(e.diag.schema_name[:7], "pg_temp")
@@ -282,7 +282,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         cur = self.conn.cursor()
         try:
             cur.execute("select * from nonexist")
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
 
         e1 = pickle.loads(pickle.dumps(e))
@@ -297,7 +297,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         import pickle
         try:
             psycopg2.connect('dbname=nosuchdatabasemate')
-        except psycopg2.Error, exc:
+        except psycopg2.Error as exc:
             e = exc
 
         e1 = pickle.loads(pickle.dumps(e))

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -145,7 +145,7 @@ class DeadlockSerializationTests(ConnectingTestCase):
                 step1.set()
                 step2.wait()
                 curs.execute("LOCK table2 IN ACCESS EXCLUSIVE MODE")
-            except psycopg2.DatabaseError, exc:
+            except psycopg2.DatabaseError as exc:
                 self.thread1_error = exc
                 step1.set()
             conn.close()
@@ -158,7 +158,7 @@ class DeadlockSerializationTests(ConnectingTestCase):
                 curs.execute("LOCK table2 IN ACCESS EXCLUSIVE MODE")
                 step2.set()
                 curs.execute("LOCK table1 IN ACCESS EXCLUSIVE MODE")
-            except psycopg2.DatabaseError, exc:
+            except psycopg2.DatabaseError as exc:
                 self.thread2_error = exc
                 step2.set()
             conn.close()
@@ -195,7 +195,7 @@ class DeadlockSerializationTests(ConnectingTestCase):
                 step2.wait()
                 curs.execute("UPDATE table1 SET name='task1' WHERE id = 1")
                 conn.commit()
-            except psycopg2.DatabaseError, exc:
+            except psycopg2.DatabaseError as exc:
                 self.thread1_error = exc
                 step1.set()
             conn.close()
@@ -207,7 +207,7 @@ class DeadlockSerializationTests(ConnectingTestCase):
                 step1.wait()
                 curs.execute("UPDATE table1 SET name='task2' WHERE id = 1")
                 conn.commit()
-            except psycopg2.DatabaseError, exc:
+            except psycopg2.DatabaseError as exc:
                 self.thread2_error = exc
             step2.set()
             conn.close()

--- a/tests/test_types_basic.py
+++ b/tests/test_types_basic.py
@@ -443,7 +443,7 @@ class ByteaParserTest(unittest.TestCase):
     def setUp(self):
         try:
             self._cast = self._import_cast()
-        except Exception, e:
+        except Exception as e:
             self._cast = None
             self._exc = e
 

--- a/tests/test_types_extras.py
+++ b/tests/test_types_extras.py
@@ -113,7 +113,7 @@ class TypesExtrasTests(ConnectingTestCase):
             psycopg2.extensions.adapt, Foo(), ext.ISQLQuote, None)
         try:
             psycopg2.extensions.adapt(Foo(), ext.ISQLQuote, None)
-        except psycopg2.ProgrammingError, err:
+        except psycopg2.ProgrammingError as err:
             self.failUnless(str(err) == "can't adapt type 'Foo'")
 
     def test_point_array(self):

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -212,7 +212,7 @@ class WithCursorTestCase(WithTestCase):
                 with conn.cursor('named') as cur:
                     cur.execute("select 1/0")
                     cur.fetchone()
-        except psycopg2.DataError, e:
+        except psycopg2.DataError as e:
             self.assertEqual(e.pgcode, '22012')
         else:
             self.fail("where is my exception?")

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -116,7 +116,7 @@ class ConnectingTestCase(unittest.TestCase):
     def connect(self, **kwargs):
         try:
             self._conns
-        except AttributeError, e:
+        except AttributeError as e:
             raise AttributeError(
                 "%s (did you forget to call ConnectingTestCase.setUp()?)"
                 % e)
@@ -149,7 +149,7 @@ class ConnectingTestCase(unittest.TestCase):
             conn = self.connect(**kwargs)
             if conn.async_ == 1:
                 self.wait(conn)
-        except psycopg2.OperationalError, e:
+        except psycopg2.OperationalError as e:
             # If pgcode is not set it is a genuine connection error
             # Otherwise we tried to run some bad operation in the connection
             # (e.g. bug #482) and we'd rather know that.
@@ -388,7 +388,7 @@ def skip_if_no_superuser(f):
         from psycopg2 import ProgrammingError
         try:
             return f(self)
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             import psycopg2.errorcodes
             if e.pgcode == psycopg2.errorcodes.INSUFFICIENT_PRIVILEGE:
                 self.skipTest("skipped because not superuser")


### PR DESCRIPTION
The syntax `except Exception, exc:` is deprecated. All Python versions supported by psycopg2 support the newer, modern syntax. Forward compatible with future Python versions.