### PR TITLE
Remove io.TextIOBase workaround for Python <= 2.5

### DIFF
--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -25,7 +25,7 @@
 import sys
 import string
 from testutils import (unittest, ConnectingTestCase, decorate_all_tests,
-    skip_if_no_iobase, skip_before_postgres, slow)
+    skip_before_postgres, slow)
 from cStringIO import StringIO
 from itertools import cycle, izip
 from subprocess import Popen, PIPE
@@ -131,7 +131,6 @@ class CopyTests(ConnectingTestCase):
         finally:
             curs.close()
 
-    @skip_if_no_iobase
     def test_copy_text(self):
         self.conn.set_client_encoding('latin1')
         self._create_temp_table()  # the above call closed the xn
@@ -154,7 +153,6 @@ class CopyTests(ConnectingTestCase):
         f.seek(0)
         self.assertEqual(f.readline().rstrip(), about)
 
-    @skip_if_no_iobase
     def test_copy_bytes(self):
         self.conn.set_client_encoding('latin1')
         self._create_temp_table()  # the above call closed the xn
@@ -176,7 +174,6 @@ class CopyTests(ConnectingTestCase):
         f.seek(0)
         self.assertEqual(f.readline().rstrip(), about)
 
-    @skip_if_no_iobase
     def test_copy_expert_textiobase(self):
         self.conn.set_client_encoding('latin1')
         self._create_temp_table()  # the above call closed the xn

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -261,20 +261,6 @@ def skip_if_no_namedtuple(f):
     return skip_if_no_namedtuple_
 
 
-def skip_if_no_iobase(f):
-    """Skip a test if io.TextIOBase is not available."""
-    @wraps(f)
-    def skip_if_no_iobase_(self):
-        try:
-            from io import TextIOBase                       # noqa
-        except ImportError:
-            return self.skipTest("io.TextIOBase not found.")
-        else:
-            return f(self)
-
-    return skip_if_no_iobase_
-
-
 def skip_before_postgres(*ver):
     """Skip a test on PostgreSQL before a certain version."""
     ver = ver + (0,) * (3 - len(ver))


### PR DESCRIPTION
`io.TextIOBase` is available on all Python versions supported by psycopg2. Can remove all workarounds.