### PR TITLE
Remove use of skip_before_python for unsupported Python versions

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -26,7 +26,7 @@ import os
 import sys
 from subprocess import Popen
 
-from testutils import (unittest, skip_before_python, skip_before_postgres,
+from testutils import (unittest, skip_before_postgres,
     ConnectingTestCase, skip_copy_if_green, script_to_py3, slow)
 
 import psycopg2
@@ -276,7 +276,6 @@ class ExceptionsTestCase(ConnectingTestCase):
         self.assertEqual(e.diag.constraint_name, "chk_eq1")
         self.assertEqual(e.diag.datatype_name, None)
 
-    @skip_before_python(2, 5)
     def test_pickle(self):
         import pickle
         cur = self.conn.cursor()
@@ -291,7 +290,6 @@ class ExceptionsTestCase(ConnectingTestCase):
         self.assertEqual(e.pgcode, e1.pgcode)
         self.assert_(e1.cursor is None)
 
-    @skip_before_python(2, 5)
     def test_pickle_connection_error(self):
         # segfaults on psycopg 2.5.1 - see ticket #170
         import pickle

--- a/tests/test_types_basic.py
+++ b/tests/test_types_basic.py
@@ -272,7 +272,6 @@ class TypesBasicTests(ConnectingTestCase):
         o2 = self.execute("select %s;", (o1,))
         self.assertEqual(memoryview, type(o2[0]))
 
-    @testutils.skip_before_python(2, 6)
     def testAdaptBytearray(self):
         o1 = bytearray(range(256))
         o2 = self.execute("select %s;", (o1,))


### PR DESCRIPTION
psycopg2 does not support Python < 2.6, remove all test guards for these versions.