### PR TITLE
Remove workaround for decimal module

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -72,14 +72,10 @@ _ext.register_adapter(type(None), _ext.NoneAdapter)
 # Register the Decimal adapter here instead of in the C layer.
 # This way a new class is registered for each sub-interpreter.
 # See ticket #52
-try:
-    from decimal import Decimal
-except ImportError:
-    pass
-else:
-    from psycopg2._psycopg import Decimal as Adapter
-    _ext.register_adapter(Decimal, Adapter)
-    del Decimal, Adapter
+from decimal import Decimal
+from psycopg2._psycopg import Decimal as Adapter
+_ext.register_adapter(Decimal, Adapter)
+del Decimal, Adapter
 
 
 def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -98,11 +98,7 @@ class CursorTests(ConnectingTestCase):
             cur.mogrify(u"SELECT %s;", (snowman,)))
 
     def test_mogrify_decimal_explodes(self):
-        # issue #7: explodes on windows with python 2.5 and psycopg 2.2.2
-        try:
-            from decimal import Decimal
-        except:
-            return
+        from decimal import Decimal
 
         conn = self.conn
         cur = conn.cursor()
@@ -138,12 +134,8 @@ class CursorTests(ConnectingTestCase):
         self.assertEqual(42, curs.cast(20, '42'))
         self.assertAlmostEqual(3.14, curs.cast(700, '3.14'))
 
-        try:
-            from decimal import Decimal
-        except ImportError:
-            self.assertAlmostEqual(123.45, curs.cast(1700, '123.45'))
-        else:
-            self.assertEqual(Decimal('123.45'), curs.cast(1700, '123.45'))
+        from decimal import Decimal
+        self.assertEqual(Decimal('123.45'), curs.cast(1700, '123.45'))
 
         from datetime import date
         self.assertEqual(date(2011, 1, 2), curs.cast(1082, '2011-01-02'))


### PR DESCRIPTION
The decimal module is available on all Python versions supported by psycopg2. It has been available since Python 2.4. No need to catch an `ImportError`.

https://docs.python.org/2/library/decimal.html