### PR TITLE
Always prefer a dict literal over dict()

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -340,7 +340,7 @@ class ParseDsnTestCase(ConnectingTestCase):
 
         self.assertEqual(
             ext.parse_dsn('dbname=test user=tester password=secret'),
-            dict(user='tester', password='secret', dbname='test'),
+            {'user': 'tester', 'password': 'secret', 'dbname': 'test'},
             "simple DSN parsed")
 
         self.assertRaises(ProgrammingError, ext.parse_dsn,
@@ -348,7 +348,7 @@ class ParseDsnTestCase(ConnectingTestCase):
 
         self.assertEqual(
             ext.parse_dsn("dbname='test 2' user=tester password=secret"),
-            dict(user='tester', password='secret', dbname='test 2'),
+            {'user': 'tester', 'password': 'secret', 'dbname': 'test 2'},
             "DSN with quoting parsed")
 
         # Can't really use assertRaisesRegexp() here since we need to
@@ -369,7 +369,7 @@ class ParseDsnTestCase(ConnectingTestCase):
     @skip_before_libpq(9, 2)
     def test_parse_dsn_uri(self):
         self.assertEqual(ext.parse_dsn('postgresql://tester:secret@/test'),
-                         dict(user='tester', password='secret', dbname='test'),
+                         {'user': 'tester', 'password': 'secret', 'dbname': 'test'},
                          "valid URI dsn parsed")
 
         raised = False

--- a/tests/test_fast_executemany.py
+++ b/tests/test_fast_executemany.py
@@ -154,7 +154,7 @@ class TestExecuteValues(FastExecuteTestMixin, testutils.ConnectingTestCase):
         cur = self.conn.cursor()
         psycopg2.extras.execute_values(cur,
             "insert into testfast (id, date, val) values %s",
-            (dict(id=i, date=date(2017, 1, i + 1), val=i * 10, foo="bar")
+            ({'id': i, 'date': date(2017, 1, i + 1), 'val': i * 10, 'foo': "bar"}
                 for i in range(10)),
             template='(%(id)s, %(date)s, %(val)s)')
         cur.execute("select id, date, val from testfast order by id")


### PR DESCRIPTION
Literals are a more idiomatic style and always faster.

Admittedly, the performance is a micro-optimization and doesn't matter for these tests, but as a matter of style and habit, always use a literal.

For completeness:

$ python3 -m timeit 'dict(a=1, b=2, c=3)'
10000000 loops, best of 3: 0.188 usec per loop
$ python3 -m timeit '{"a": 1, "b": 2, "c": 3}'
10000000 loops, best of 3: 0.0693 usec per loop