### PR TITLE
Remove "from __future__ import with_statement"

### DIFF
--- a/tests/test_types_extras.py
+++ b/tests/test_types_extras.py
@@ -13,7 +13,6 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
-from __future__ import with_statement
 
 import re
 import sys

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -22,9 +22,6 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-
-from __future__ import with_statement
-
 import psycopg2
 import psycopg2.extensions as ext
 


### PR DESCRIPTION
All versions of Python supported by psycopg2 have builtin support for the with statement. The import is unnecessary noise.