### PR TITLE
Update documentation to reflect JSON import behavior

### DIFF
--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -539,17 +539,13 @@ fields to JSON) you can use the `register_json()` function.
 
 .. __: http://people.planetpostgresql.org/andrew/index.php?/archives/255-JSON-for-PG-9.2-...-and-now-for-9.1!.html
 
-The Python library used by default to convert Python objects to JSON and to
-parse data from the database depends on the language version: with Python 2.6
-and following the :py:mod:`json` module from the standard library is used;
-with previous versions the `simplejson`_ module is used if available. Note
-that the last `!simplejson` version supporting Python 2.4 is the 2.0.9.
+The Python :py:mod:`json` module is used by default to convert Python objects
+to JSON and to parse data from the database.
 
 .. _JSON: http://www.json.org/
 .. |pgjson| replace:: :sql:`json`
 .. |jsonb| replace:: :sql:`jsonb`
 .. _pgjson: http://www.postgresql.org/docs/current/static/datatype-json.html
-.. _simplejson: http://pypi.python.org/pypi/simplejson/
 
 In order to pass a Python object to the database as query argument you can use
 the `Json` adapter::

--- a/lib/_json.py
+++ b/lib/_json.py
@@ -49,10 +49,8 @@ class Json(object):
     :sql:`json` data type.
 
     `!Json` can be used to wrap any object supported by the provided *dumps*
-    function.  If none is provided, the standard :py:func:`json.dumps()` is
-    used (`!simplejson` for Python < 2.6;
-    `~psycopg2.extensions.ISQLQuote.getquoted()` will raise `!ImportError` if
-    the module is not available).
+    function. If none is provided, the standard :py:func:`json.dumps()` is
+    used.
 
     """
     def __init__(self, adapted, dumps=None):


### PR DESCRIPTION
The docs don't need to describe what will happen on Python versions before 2.6 as they are unsupported by psycopg2.

Should have been included in commit d58844e5483483240f97537e9a77b4e79cea2ab3, but was missed.