### PR TITLE
Always import the system unittest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,7 +29,7 @@ warnings.simplefilter('error')  # noqa
 
 import sys
 from testconfig import dsn
-from testutils import unittest
+import unittest
 
 import test_async
 import test_bugX000

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -23,7 +23,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-from testutils import unittest, skip_before_postgres, slow
+import unittest
+from testutils import skip_before_postgres, slow
 
 import psycopg2
 from psycopg2 import extensions as ext

--- a/tests/test_async_keyword.py
+++ b/tests/test_async_keyword.py
@@ -29,7 +29,8 @@ import psycopg2
 from psycopg2 import extras
 
 from testconfig import dsn
-from testutils import ConnectingTestCase, unittest, skip_before_postgres, slow
+import unittest
+from testutils import ConnectingTestCase, skip_before_postgres, slow
 
 from test_replication import ReplicationTestCase, skip_repl_if_green
 from psycopg2.extras import LogicalReplicationConnection, StopReplication

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -31,7 +31,8 @@ import psycopg2.extensions
 from psycopg2 import extras
 
 from testconfig import dsn
-from testutils import unittest, ConnectingTestCase, skip_before_postgres, slow
+import unittest
+from testutils import ConnectingTestCase, skip_before_postgres, slow
 
 
 class CancelTests(ConnectingTestCase):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -24,7 +24,8 @@
 
 import sys
 import string
-from testutils import (unittest, ConnectingTestCase, decorate_all_tests,
+import unittest
+from testutils import (ConnectingTestCase, decorate_all_tests,
     skip_before_postgres, slow)
 from cStringIO import StringIO
 from itertools import cycle, izip

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -26,7 +26,8 @@ import time
 import pickle
 import psycopg2
 import psycopg2.extensions
-from testutils import (unittest, ConnectingTestCase, skip_before_postgres,
+import unittest
+from testutils import (ConnectingTestCase, skip_before_postgres,
     skip_if_no_getrefcount, slow, skip_if_no_superuser,
     skip_if_windows)
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -25,7 +25,8 @@
 import math
 import psycopg2
 from psycopg2.tz import FixedOffsetTimezone, ZERO
-from testutils import unittest, ConnectingTestCase, skip_before_postgres
+import unittest
+from testutils import ConnectingTestCase, skip_before_postgres
 
 
 def total_seconds(d):

--- a/tests/test_errcodes.py
+++ b/tests/test_errcodes.py
@@ -22,7 +22,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-from testutils import unittest, ConnectingTestCase, slow
+import unittest
+from testutils import ConnectingTestCase, slow
 
 try:
     reload

--- a/tests/test_extras_dictcursor.py
+++ b/tests/test_extras_dictcursor.py
@@ -18,7 +18,8 @@ import time
 from datetime import timedelta
 import psycopg2
 import psycopg2.extras
-from testutils import unittest, ConnectingTestCase, skip_before_postgres
+import unittest
+from testutils import ConnectingTestCase, skip_before_postgres
 
 
 class ExtrasDictCursorTests(ConnectingTestCase):

--- a/tests/test_fast_executemany.py
+++ b/tests/test_fast_executemany.py
@@ -17,7 +17,7 @@
 from datetime import date
 
 import testutils
-from testutils import unittest
+import unittest
 
 import psycopg2
 import psycopg2.extras

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -20,7 +20,7 @@ import sys
 from functools import wraps
 
 import testutils
-from testutils import unittest
+import unittest
 
 import psycopg2
 import psycopg2.extras

--- a/tests/test_lobject.py
+++ b/tests/test_lobject.py
@@ -29,7 +29,8 @@ from functools import wraps
 
 import psycopg2
 import psycopg2.extensions
-from testutils import (unittest, decorate_all_tests, skip_if_tpc_disabled,
+import unittest
+from testutils import (decorate_all_tests, skip_if_tpc_disabled,
     ConnectingTestCase, skip_if_green, slow)
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -26,7 +26,8 @@ import os
 import sys
 from subprocess import Popen
 
-from testutils import (unittest, skip_before_postgres,
+import unittest
+from testutils import (skip_before_postgres,
     ConnectingTestCase, skip_copy_if_green, script_to_py3, slow)
 
 import psycopg2

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -22,7 +22,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
-from testutils import unittest
+import unittest
 
 import psycopg2
 from psycopg2 import extensions

--- a/tests/test_psycopg2_dbapi20.py
+++ b/tests/test_psycopg2_dbapi20.py
@@ -25,7 +25,8 @@
 import dbapi20
 import dbapi20_tpc
 from testutils import skip_if_tpc_disabled
-from testutils import unittest, decorate_all_tests
+import unittest
+from testutils import decorate_all_tests
 import psycopg2
 
 from testconfig import dsn

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -24,7 +24,8 @@
 
 import sys
 import testutils
-from testutils import unittest, ConnectingTestCase
+import unittest
+from testutils import ConnectingTestCase
 
 import psycopg2
 import psycopg2.extensions

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -27,7 +27,8 @@ from psycopg2.extras import (
     PhysicalReplicationConnection, LogicalReplicationConnection, StopReplication)
 
 import testconfig
-from testutils import unittest, ConnectingTestCase
+import unittest
+from testutils import ConnectingTestCase
 from testutils import skip_before_postgres, skip_if_green
 
 skip_repl_if_green = skip_if_green("replication not supported in green mode")

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -24,7 +24,8 @@
 
 import datetime as dt
 from cStringIO import StringIO
-from testutils import (unittest, ConnectingTestCase,
+import unittest
+from testutils import (ConnectingTestCase,
     skip_before_postgres, skip_before_python, skip_copy_if_green)
 
 import psycopg2

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -23,7 +23,8 @@
 # License for more details.
 
 import threading
-from testutils import unittest, ConnectingTestCase, skip_before_postgres, slow
+import unittest
+from testutils import ConnectingTestCase, skip_before_postgres, slow
 
 import psycopg2
 from psycopg2.extensions import (

--- a/tests/test_types_basic.py
+++ b/tests/test_types_basic.py
@@ -27,7 +27,8 @@ import decimal
 import sys
 from functools import wraps
 import testutils
-from testutils import unittest, ConnectingTestCase, decorate_all_tests
+import unittest
+from testutils import ConnectingTestCase, decorate_all_tests
 
 import psycopg2
 

--- a/tests/test_types_extras.py
+++ b/tests/test_types_extras.py
@@ -22,7 +22,8 @@ from datetime import date, datetime
 from functools import wraps
 from pickle import dumps, loads
 
-from testutils import (unittest, skip_if_no_uuid, skip_before_postgres,
+import unittest
+from testutils import (skip_if_no_uuid, skip_before_postgres,
     ConnectingTestCase, decorate_all_tests, py3_raises_typeerror, slow)
 
 import psycopg2

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -25,7 +25,8 @@
 import psycopg2
 import psycopg2.extensions as ext
 
-from testutils import unittest, ConnectingTestCase
+import unittest
+from testutils import ConnectingTestCase
 
 
 class WithTestCase(ConnectingTestCase):


### PR DESCRIPTION
There is no need to import `testutils.unittest` instead of simply `unittest`. They are simple aliases. Use system `unittest` to be more regular, consistent as well as idiomatic with the wider Python community.