### PR TITLE
Drop leading 0's from numeric literals

### DIFF
--- a/tests/test_types_extras.py
+++ b/tests/test_types_extras.py
@@ -1619,7 +1619,7 @@ class RangeCasterTestCase(ConnectingTestCase):
         from psycopg2.tz import FixedOffsetTimezone
         cur = self.conn.cursor()
 
-        d1 = date(2012, 01, 01)
+        d1 = date(2012, 1, 1)
         d2 = date(2012, 12, 31)
         r = DateRange(d1, d2)
         cur.execute("select %s", (r,))


### PR DESCRIPTION
Not compatible with Python3. Makes the code more forward compatible with modern Pythons.

In Python2, it was an alternative syntax for octal.

```
$ python3
>>> 01
  File "<stdin>", line 1
    01
     ^
SyntaxError: invalid token
```