### PR TITLE
Use builtin function next() throughout project

### DIFF
--- a/doc/src/tools/stitch_text.py
+++ b/doc/src/tools/stitch_text.py
@@ -19,10 +19,7 @@ def main():
 
 def iter_file_base(fn):
     f = open(fn)
-    if sys.version_info[0] >= 3:
-        have_line = iter(f).__next__
-    else:
-        have_line = iter(f).next
+    have_line = iter(f).__next__
 
     while not have_line().startswith('.. toctree'):
         pass

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -110,16 +110,16 @@ class DictCursorBase(_cursor):
         try:
             if self._prefetch:
                 res = super(DictCursorBase, self).__iter__()
-                first = res.next()
+                first = next(res)
             if self._query_executed:
                 self._build_index()
             if not self._prefetch:
                 res = super(DictCursorBase, self).__iter__()
-                first = res.next()
+                first = next(res)
 
             yield first
             while 1:
-                yield res.next()
+                yield next(res)
         except StopIteration:
             return
 
@@ -349,7 +349,7 @@ class NamedTupleCursor(_cursor):
     def __iter__(self):
         try:
             it = super(NamedTupleCursor, self).__iter__()
-            t = it.next()
+            t = next(it)
 
             nt = self.Record
             if nt is None:
@@ -358,7 +358,7 @@ class NamedTupleCursor(_cursor):
             yield nt._make(t)
 
             while 1:
-                yield nt._make(it.next())
+                yield nt._make(next(it))
         except StopIteration:
             return
 
@@ -1144,7 +1144,7 @@ def _paginate(seq, page_size):
     while 1:
         try:
             for i in xrange(page_size):
-                page.append(it.next())
+                page.append(next(it))
             yield page
             page = []
         except StopIteration:

--- a/lib/sql.py
+++ b/lib/sql.py
@@ -276,7 +276,7 @@ class SQL(Composable):
         rv = []
         it = iter(seq)
         try:
-            rv.append(it.next())
+            rv.append(next(it))
         except StopIteration:
             pass
         else:

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -334,9 +334,9 @@ class CursorTests(ConnectingTestCase):
         # timestamp will not be influenced by the pause in Python world.
         curs.execute("""select clock_timestamp() from generate_series(1,2)""")
         i = iter(curs)
-        t1 = (i.next())[0]  # the brackets work around a 2to3 bug
+        t1 = next(i)[0]
         time.sleep(0.2)
-        t2 = (i.next())[0]
+        t2 = next(i)[0]
         self.assert_((t2 - t1).microseconds * 1e-6 < 0.1,
             "named cursor records fetched in 2 roundtrips (delta: %s)"
             % (t2 - t1))

--- a/tests/test_extras_dictcursor.py
+++ b/tests/test_extras_dictcursor.py
@@ -310,22 +310,22 @@ class NamedTupleCursorTest(ConnectingTestCase):
         i = iter(curs)
         self.assertEqual(curs.rownumber, 0)
 
-        t = i.next()
+        t = next(i)
         self.assertEqual(t.i, 1)
         self.assertEqual(t.s, 'foo')
         self.assertEqual(curs.rownumber, 1)
         self.assertEqual(curs.rowcount, 3)
 
-        t = i.next()
+        t = next(i)
         self.assertEqual(t.i, 2)
         self.assertEqual(t.s, 'bar')
         self.assertEqual(curs.rownumber, 2)
         self.assertEqual(curs.rowcount, 3)
 
-        t = i.next()
+        t = next(i)
         self.assertEqual(t.i, 3)
         self.assertEqual(t.s, 'baz')
-        self.assertRaises(StopIteration, i.next)
+        self.assertRaises(StopIteration, next, i)
         self.assertEqual(curs.rownumber, 3)
         self.assertEqual(curs.rowcount, 3)
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -344,11 +344,11 @@ class ComposedTest(ConnectingTestCase):
     def test_iter(self):
         obj = sql.Composed([sql.SQL("foo"), sql.SQL('bar')])
         it = iter(obj)
-        i = it.next()
+        i = next(it)
         self.assertEqual(i, sql.SQL('foo'))
-        i = it.next()
+        i = next(it)
         self.assertEqual(i, sql.SQL('bar'))
-        self.assertRaises(StopIteration, it.next)
+        self.assertRaises(StopIteration, next, it)
 
 
 class PlaceholderTest(ConnectingTestCase):


### PR DESCRIPTION
Available since Python 2.6. Use of `.next()` is deprecated and not supported in Python 3. Forward compatible with modern Python.

https://docs.python.org/2/library/functions.html#next