### PR TITLE
Remove sorted() workaround; available on all supported Pythons

### DIFF
--- a/examples/dialtone.py
+++ b/examples/dialtone.py
@@ -17,13 +17,6 @@ from datetime import datetime
 import psycopg2
 from psycopg2.extensions import adapt, register_adapter
 
-try:
-    sorted()
-except:
-    def sorted(seq):
-        seq.sort()
-        return seq
-
 # Here is the adapter for every object that we may ever need to 
 # insert in the database. It receives the original object and does
 # its job on that instance


### PR DESCRIPTION
Introduced in Python 2.4 and the oldest supported Python is 2.7.

https://docs.python.org/2/library/functions.html#sorted