### PR TITLE
Remove unnecessary script_to_py3; make scripts compatible instead

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -35,7 +35,7 @@ import psycopg2.errorcodes
 from psycopg2 import extensions as ext
 
 from testutils import (
-    script_to_py3, unittest, decorate_all_tests, skip_if_no_superuser,
+    unittest, decorate_all_tests, skip_if_no_superuser,
     skip_before_postgres, skip_after_postgres, skip_before_libpq,
     ConnectingTestCase, skip_if_tpc_disabled, skip_if_windows, slow)
 
@@ -1566,7 +1566,7 @@ while True:
     cur.execute(%(query)r, ("Hello, world!",))
 """ % {'dsn': dsn, 'query': query})
 
-        proc = sp.Popen([sys.executable, '-c', script_to_py3(script)],
+        proc = sp.Popen([sys.executable, '-c', script],
             stdout=sp.PIPE, stderr=sp.PIPE)
         (out, err) = proc.communicate()
         self.assertNotEqual(proc.returncode, 0)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -32,7 +32,7 @@ from subprocess import Popen, PIPE
 
 import psycopg2
 import psycopg2.extensions
-from testutils import skip_copy_if_green, script_to_py3
+from testutils import skip_copy_if_green
 from testconfig import dsn
 
 
@@ -324,7 +324,7 @@ except psycopg2.ProgrammingError:
 conn.close()
 """ % {'dsn': dsn})
 
-        proc = Popen([sys.executable, '-c', script_to_py3(script)])
+        proc = Popen([sys.executable, '-c', script])
         proc.communicate()
         self.assertEqual(0, proc.returncode)
 
@@ -343,7 +343,7 @@ except psycopg2.ProgrammingError:
 conn.close()
 """ % {'dsn': dsn})
 
-        proc = Popen([sys.executable, '-c', script_to_py3(script)], stdout=PIPE)
+        proc = Popen([sys.executable, '-c', script], stdout=PIPE)
         proc.communicate()
         self.assertEqual(0, proc.returncode)
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -27,7 +27,7 @@ import sys
 from subprocess import Popen
 
 from testutils import (unittest, skip_before_postgres,
-    ConnectingTestCase, skip_copy_if_green, script_to_py3, slow)
+    ConnectingTestCase, skip_copy_if_green, slow)
 
 import psycopg2
 
@@ -322,7 +322,7 @@ sys.path.insert(0, %r)
 import _psycopg
 """ % (pardir, pkgdir))
 
-        proc = Popen([sys.executable, '-c', script_to_py3(script)])
+        proc = Popen([sys.executable, '-c', script])
         proc.communicate()
         self.assertEqual(0, proc.returncode)
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -26,7 +26,7 @@ from testutils import unittest
 
 import psycopg2
 from psycopg2 import extensions
-from testutils import ConnectingTestCase, script_to_py3, slow
+from testutils import ConnectingTestCase, slow
 from testconfig import dsn
 
 import sys
@@ -61,7 +61,7 @@ import %(module)s as psycopg2
 import %(module)s.extensions as ext
 conn = psycopg2.connect(%(dsn)r)
 conn.set_isolation_level(ext.ISOLATION_LEVEL_AUTOCOMMIT)
-print conn.get_backend_pid()
+print(conn.get_backend_pid())
 curs = conn.cursor()
 curs.execute("NOTIFY " %(name)r %(payload)r)
 curs.close()
@@ -70,7 +70,7 @@ conn.close()
             'module': psycopg2.__name__,
             'dsn': dsn, 'sec': sec, 'name': name, 'payload': payload})
 
-        return Popen([sys.executable, '-c', script_to_py3(script)], stdout=PIPE)
+        return Popen([sys.executable, '-c', script], stdout=PIPE)
 
     @slow
     def test_notifies_received_on_poll(self):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -371,34 +371,6 @@ def skip_if_windows(f):
     return skip_if_windows_
 
 
-def script_to_py3(script):
-    """Convert a script to Python3 syntax if required."""
-    if sys.version_info[0] < 3:
-        return script
-
-    import tempfile
-    f = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
-    f.write(script.encode())
-    f.flush()
-    filename = f.name
-    f.close()
-
-    # 2to3 is way too chatty
-    import logging
-    logging.basicConfig(filename=os.devnull)
-
-    from lib2to3.main import main
-    if main("lib2to3.fixes", ['--no-diffs', '-w', '-n', filename]):
-        raise Exception('py3 conversion failed')
-
-    f2 = open(filename)
-    try:
-        return f2.read()
-    finally:
-        f2.close()
-        os.remove(filename)
-
-
 class py3_raises_typeerror(object):
     def __enter__(self):
         pass


### PR DESCRIPTION
Part of the work towards moving tests out of the installed package.