### PR TITLE
Officially deprecate psycopg1 module

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,8 @@ What's new in psycopg 2.8
 Other changes:
 
 - Dropped support for Python 2.6, 3.2, 3.3.
-
+- Importing psycopg2.psycopg1 is now deprecated. Use psycopg2 instead. The
+  psycopg1 module will be removed in a future version.
 
 What's new in psycopg 2.7.4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/psycopg1.py
+++ b/lib/psycopg1.py
@@ -27,6 +27,7 @@ old code while porting to psycopg 2. Import it as follows::
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
+import warnings
 
 from psycopg2 import _psycopg as _2psycopg   # noqa
 from psycopg2.extensions import cursor as _2cursor
@@ -35,6 +36,12 @@ from psycopg2.extensions import connection as _2connection
 from psycopg2 import *      # noqa
 from psycopg2 import extensions as _ext
 _2connect = connect
+
+warnings.warn(
+    'Importing psycopg1 is deprecated. Use psycopg2 module instead. The '
+    'psycopg1 module will be removed in a future version.',
+    DeprecationWarning,
+)
 
 
 def connect(*args, **kwargs):


### PR DESCRIPTION
Per the module's comment, using `psycopg1` is considered a temporary hack that should not be relied on long term. Import now reports a warning. The warning instructs users to use the modern module instead. Allows
removing the workaround in a future version.

The `psycopg1` module has been available since the very first psycopg2 release. There has been plenty of time for users to migrate.