### PR TITLE
Fix definition of BUILD_DIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@
 #   make check  # this requires setting up a test database with the correct user
 
 PYTHON := python$(PYTHON_VERSION)
-PYTHON_VERSION ?= $(shell $(PYTHON) -c 'import sys; print ("%d.%d" % sys.version_info[:2])')
-BUILD_DIR = $(shell pwd)/build/lib.$(PYTHON_VERSION)
+PYTHON_PLATFORM := $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_platform())')
+PYTHON_VERSION ?= $(shell $(PYTHON) -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+BUILD_DIR = $(shell pwd)/build/lib.$(PYTHON_PLATFORM)-$(PYTHON_VERSION)
 
 SOURCE_C := $(wildcard psycopg/*.c psycopg/*.h)
 SOURCE_PY := $(wildcard lib/*.py)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -553,7 +553,7 @@ class CursorTests(ConnectingTestCase):
         # Issue #443 is in the async code too. Since the fix is duplicated,
         # so is the test.
         control_conn = self.conn
-        connect_func = lambda: self.connect(async=True)
+        connect_func = lambda: self.connect(async_=True)
         wait_func = psycopg2.extras.wait_select
         self._test_external_close(control_conn, connect_func, wait_func)
 


### PR DESCRIPTION
The Python's platform should be included in the build dir. Was previously missing resulting in the incorrect path.
    
Fixing the build dir allows testing psycopg2 without first calling `python setup.py install`.
    
Exposed a missing use of the deprecated `async` keyword.
    
For additional information on how to calculate the build dir, see the following SO post:
    
https://stackoverflow.com/a/14369968

Helps work towards moving tests outside of the installed package.