### PR TITLE
Drop long deprecated function register_tstz_w_secs()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Other changes:
 
 - Dropped support for Python 2.6, 3.2, 3.3.
 - Dropped `psycopg1` module.
+- Dropped deprecated ``register_tstz_w_secs()`` (was previously a no-op).
 
 
 What's new in psycopg 2.7.4

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -1025,20 +1025,6 @@ parameters.  By reducing the number of server roundtrips the performance can be
     .. versionadded:: 2.7
 
 
-
-.. index::
-    single: Time zones; Fractional
-
-Fractional time zones
----------------------
-
-.. autofunction:: register_tstz_w_secs
-
-    .. versionadded:: 2.0.9
-
-    .. versionchanged:: 2.2.2
-        function is no-op: see :ref:`tz-handling`.
-
 .. index::
    pair: Example; Coroutine;
 

--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -560,8 +560,7 @@ rounded to the nearest minute, with an error of up to 30 seconds.
 
 .. versionchanged:: 2.2.2
     timezones with seconds are supported (with rounding). Previously such
-    timezones raised an error.  In order to deal with them in previous
-    versions use `psycopg2.extras.register_tstz_w_secs()`.
+    timezones raised an error.
 
 
 .. index::

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -719,18 +719,6 @@ def register_inet(oid=None, conn_or_curs=None):
     return _ext.INET
 
 
-def register_tstz_w_secs(oids=None, conn_or_curs=None):
-    """The function used to register an alternate type caster for
-    :sql:`TIMESTAMP WITH TIME ZONE` to deal with historical time zones with
-    seconds in the UTC offset.
-
-    These are now correctly handled by the default type caster, so currently
-    the function doesn't do anything.
-    """
-    import warnings
-    warnings.warn("deprecated", DeprecationWarning)
-
-
 def wait_select(conn):
     """Wait until a connection or cursor has data available.
 


### PR DESCRIPTION
Deprecated in commit b263fbf274f9085a1bddca018ed8a50d37023fc7 on 2010-01-13. The deprecation warning was first released in version 2.2.2. 

The function used to register an alternate type caster for `TIMESTAMP WITH TIME ZONE` to deal with historical time zones with seconds in the UTC offset. These are now correctly handled by the default type caster, so currently the function was changed to not do anything (a no-op).