### PR TITLE
use accessor macros for pypy3 compatibility

### DIFF
--- a/psycopg/adapter_datetime.c
+++ b/psycopg/adapter_datetime.c
@@ -100,7 +100,7 @@ _pydatetime_string_delta(pydatetimeObject *self)
 
     char buffer[8];
     int i;
-    int a = obj->microseconds;
+    int a = PyDateTime_DELTA_GET_MICROSECONDS(obj);
 
     for (i=0; i < 6 ; i++) {
         buffer[5-i] = '0' + (a % 10);
@@ -109,7 +109,9 @@ _pydatetime_string_delta(pydatetimeObject *self)
     buffer[6] = '\0';
 
     return Bytes_FromFormat("'%d days %d.%s seconds'::interval",
-                            obj->days, obj->seconds, buffer);
+                            PyDateTime_DELTA_GET_DAYS(obj),
+                            PyDateTime_DELTA_GET_SECONDS(obj),
+                            buffer);
 }
 
 static PyObject *

--- a/psycopg/adapter_datetime.c
+++ b/psycopg/adapter_datetime.c
@@ -93,12 +93,6 @@ error:
     return rv;
 }
 
-#ifndef PyDateTime_DELTA_GET_DAYS
-#define PyDateTime_DELTA_GET_DAYS(o) (o->days)
-#define PyDateTime_DELTA_GET_SECONDS(o) (o->seconds)
-#define PyDateTime_DELTA_GET_MICROSECONDS(o) (o->microseconds)
-#endif
-
 static PyObject *
 _pydatetime_string_delta(pydatetimeObject *self)
 {

--- a/psycopg/adapter_datetime.c
+++ b/psycopg/adapter_datetime.c
@@ -93,6 +93,12 @@ error:
     return rv;
 }
 
+#ifndef PyDateTime_DELTA_GET_DAYS
+#define PyDateTime_DELTA_GET_DAYS(o) (o->days)
+#define PyDateTime_DELTA_GET_SECONDS(o) (o->seconds)
+#define PyDateTime_DELTA_GET_MICROSECONDS(o) (o->microseconds)
+#endif
+
 static PyObject *
 _pydatetime_string_delta(pydatetimeObject *self)
 {

--- a/psycopg/python.h
+++ b/psycopg/python.h
@@ -87,6 +87,7 @@ typedef unsigned long Py_uhash_t;
 #ifndef PyNumber_Int
 #define PyNumber_Int           PyNumber_Long
 #endif
+
 #endif  /* PY_MAJOR_VERSION > 2 */
 
 #if PY_MAJOR_VERSION < 3
@@ -103,6 +104,10 @@ typedef unsigned long Py_uhash_t;
 #define Bytes_FromFormat PyString_FromFormat
 #define Bytes_ConcatAndDel PyString_ConcatAndDel
 #define _Bytes_Resize _PyString_Resize
+
+#define PyDateTime_DELTA_GET_DAYS(o)         (((PyDateTime_Delta*)o)->days)
+#define PyDateTime_DELTA_GET_SECONDS(o)      (((PyDateTime_Delta*)o)->seconds)
+#define PyDateTime_DELTA_GET_MICROSECONDS(o) (((PyDateTime_Delta*)o)->microseconds)
 
 #else
 


### PR DESCRIPTION
Fixes #649 .