### PR TITLE
Fixed installation on SmartOS

### DIFF
--- a/psycopg/solaris_support.c
+++ b/psycopg/solaris_support.c
@@ -1,6 +1,7 @@
 /* solaris_support.c - emulate functions missing on Solaris
  *
  * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ * Copyright (c) 2018, Joyent, Inc.
  *
  * This file is part of psycopg.
  *
@@ -28,7 +29,8 @@
 #include "psycopg/solaris_support.h"
 
 #if defined(__sun) && defined(__SVR4)
-/* timeradd is missing on Solaris */
+/* timeradd is missing on Solaris 10 */
+#ifndef timeradd
 void
 timeradd(struct timeval *a, struct timeval *b, struct timeval *c)
 {
@@ -51,4 +53,5 @@ timersub(struct timeval *a, struct timeval *b, struct timeval *c)
         c->tv_sec -= 1;
     }
 }
+#endif /* timeradd */
 #endif /* defined(__sun) && defined(__SVR4) */

--- a/psycopg/solaris_support.h
+++ b/psycopg/solaris_support.h
@@ -1,6 +1,7 @@
 /* solaris_support.h - definitions for solaris_support.c
  *
  * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ * Copyright (c) 2018, Joyent, Inc.
  *
  * This file is part of psycopg.
  *
@@ -30,8 +31,10 @@
 #if defined(__sun) && defined(__SVR4)
 #include <sys/time.h>
 
+#ifndef timeradd
 extern HIDDEN void timeradd(struct timeval *a, struct timeval *b, struct timeval *c);
 extern HIDDEN void timersub(struct timeval *a, struct timeval *b, struct timeval *c);
+#endif
 #endif
 
 #endif /* !defined(PSYCOPG_SOLARIS_SUPPORT_H) */


### PR DESCRIPTION
    timeradd is miissing on Solaris 10, but is present as a macro in
    <sys/time.h> on SmartOS, illumos, and likely Solaris 11.

Closes #677 