### PR TITLE
Complete tox testing matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,9 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py27
+envlist = py{27,34,35,36}
 
 [testenv]
 commands = make check
+whitelist_externals = make
 
 [flake8]
 max-line-length = 85


### PR DESCRIPTION
Now tests all supported Python environments. Allows testing the full matrix of Python version with a single command.

Include the command `make` in the `whitelist_externals` configuration to avoid the runtime warning:

```
  WARNING:test command found but not installed in testenv
    cmd: /usr/bin/make
    env: .../psycopg2/.tox/flake8
  Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
```