### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ external libraries, by installing the `psycopg2-binary`_ package from PyPI::
 The binary package is a practical choice for development and testing but in
 production it is advised to use the package built from sources.
 
-.. _PyPI: https://pypi.python.org/pypi/psycopg2
-.. _psycopg2-binary: https://pypi.python.org/pypi/psycopg2-binary
+.. _PyPI: https://pypi.org/project/psycopg2/
+.. _psycopg2-binary: https://pypi.org/project/psycopg2-binary/
 .. _install: http://initd.org/psycopg/docs/install.html#install-from-source
 .. _faq: http://initd.org/psycopg/docs/faq.html#faq-compile
 

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -100,5 +100,5 @@ Test packages may be uploaded on the `PyPI testing site`__ using::
 
 assuming `proper configuration`__ of ``~/.pypirc``.
 
-.. __: https://testpypi.python.org/pypi/psycopg2
+.. __: https://test.pypi.org/project/psycopg2/
 .. __: https://wiki.python.org/moin/TestPyPI

--- a/doc/src/advanced.rst
+++ b/doc/src/advanced.rst
@@ -485,7 +485,7 @@ details. You can check the `psycogreen`_ project for further informations and
 resources about the topic.
 
 .. _coroutine: http://en.wikipedia.org/wiki/Coroutine
-.. _greenlet: http://pypi.python.org/pypi/greenlet
+.. _greenlet: https://pypi.org/project/greenlet/
 .. _green threads: http://en.wikipedia.org/wiki/Green_threads
 .. _Eventlet: http://eventlet.net/
 .. _gevent: http://www.gevent.org/

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -140,7 +140,7 @@ Make sure to use an up-to-date version of :program:`pip` (you can upgrade it
 using something like ``pip install -U pip``)
 
 .. __: PyPI-binary_
-.. _PyPI-binary: https://pypi.python.org/pypi/psycopg2-binary/
+.. _PyPI-binary: https://pypi.org/project/psycopg2-binary/
 .. _wheel: http://pythonwheels.com/
 
 .. note::


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html