### PR TITLE
Travis CI: Run tests on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ language: python
 
 python:
   - 2.7
+  - 3.7-dev
   - 3.6
   - 3.5
   - 3.4
 
 install:
-  - python setup.py install
+  - pip install -U pip setuptools wheel
+  - pip install .
   - rm -rf psycopg2.egg-info
   - sudo scripts/travis_prepare.sh
 


### PR DESCRIPTION
Also, switch to wheel, because eggs caused problems on 3.7:

    ValueError: bad marshal data (unknown type code)