### PR TITLE
build fix: async is now a reserved keyword with Python3.7, rename it to async_

### DIFF
--- a/psycopg/connection.h
+++ b/psycopg/connection.h
@@ -96,7 +96,7 @@ struct connectionObject {
     int status;               /* status of the connection */
     xidObject *tpc_xid;       /* Transaction ID in two-phase commit */
 
-    long int async;           /* 1 means the connection is async */
+    long int async_;           /* 1 means the connection is async */
     int protocol;             /* protocol version */
     int server_version;       /* server version */
 
@@ -160,7 +160,7 @@ HIDDEN void conn_notice_process(connectionObject *self);
 HIDDEN void conn_notice_clean(connectionObject *self);
 HIDDEN void conn_notifies_process(connectionObject *self);
 RAISES_NEG HIDDEN int  conn_setup(connectionObject *self, PGconn *pgconn);
-HIDDEN int  conn_connect(connectionObject *self, long int async);
+HIDDEN int  conn_connect(connectionObject *self, long int async_);
 HIDDEN void conn_close(connectionObject *self);
 HIDDEN void conn_close_locked(connectionObject *self);
 RAISES_NEG HIDDEN int  conn_commit(connectionObject *self);
@@ -179,7 +179,7 @@ HIDDEN PyObject *conn_tpc_recover(connectionObject *self);
     PyErr_SetString(InterfaceError, "connection already closed"); \
     return NULL; }
 
-#define EXC_IF_CONN_ASYNC(self, cmd) if ((self)->async == 1) { \
+#define EXC_IF_CONN_ASYNC(self, cmd) if ((self)->async_ == 1) { \
     PyErr_SetString(ProgrammingError, #cmd " cannot be used "  \
     "in asynchronous mode");                                   \
     return NULL; }

--- a/psycopg/connection_int.c
+++ b/psycopg/connection_int.c
@@ -802,11 +802,11 @@ _conn_async_connect(connectionObject *self)
 }
 
 int
-conn_connect(connectionObject *self, long int async)
+conn_connect(connectionObject *self, long int async_)
 {
     int rv;
 
-    if (async == 1) {
+    if (async_ == 1) {
       Dprintf("con_connect: connecting in ASYNC mode");
       rv = _conn_async_connect(self);
     }
@@ -934,7 +934,7 @@ _conn_poll_query(connectionObject *self)
 
     case ASYNC_READ:
         Dprintf("conn_poll: async_status = ASYNC_READ");
-        if (self->async) {
+        if (self->async_) {
             res = _conn_poll_advance_read(self, pq_is_busy(self));
         }
         else {
@@ -1061,7 +1061,7 @@ conn_poll(connectionObject *self)
 
     case CONN_STATUS_CONNECTING:
         res = _conn_poll_connecting(self);
-        if (res == PSYCO_POLL_OK && self->async) {
+        if (res == PSYCO_POLL_OK && self->async_) {
             res = _conn_poll_setup_async(self);
         }
         break;
@@ -1075,7 +1075,7 @@ conn_poll(connectionObject *self)
     case CONN_STATUS_PREPARED:
         res = _conn_poll_query(self);
 
-        if (res == PSYCO_POLL_OK && self->async && self->async_cursor) {
+        if (res == PSYCO_POLL_OK && self->async_ && self->async_cursor) {
             /* An async query has just finished: parse the tuple in the
              * target cursor. */
             cursorObject *curs;

--- a/psycopg/cursor.h
+++ b/psycopg/cursor.h
@@ -124,7 +124,7 @@ while (0)
 
 #define EXC_IF_CURS_ASYNC(self, cmd) \
 do \
-    if ((self)->conn->async == 1) { \
+    if ((self)->conn->async_ == 1) { \
         PyErr_SetString(ProgrammingError, \
             #cmd " cannot be used in asynchronous mode"); \
         return NULL; } \

--- a/psycopg/cursor_type.c
+++ b/psycopg/cursor_type.c
@@ -345,7 +345,7 @@ _psyco_curs_merge_query_args(cursorObject *self,
 RAISES_NEG static int
 _psyco_curs_execute(cursorObject *self,
                     PyObject *operation, PyObject *vars,
-                    long int async, int no_result)
+                    long int async_, int no_result)
 {
     int res = -1;
     int tmp;
@@ -425,7 +425,7 @@ _psyco_curs_execute(cursorObject *self,
 
     /* At this point, the SQL statement must be str, not unicode */
 
-    tmp = pq_execute(self, Bytes_AS_STRING(self->query), async, no_result, 0);
+    tmp = pq_execute(self, Bytes_AS_STRING(self->query), async_, no_result, 0);
     Dprintf("psyco_curs_execute: res = %d, pgres = %p", tmp, self->pgres);
     if (tmp < 0) { goto exit; }
 
@@ -471,7 +471,7 @@ psyco_curs_execute(cursorObject *self, PyObject *args, PyObject *kwargs)
     EXC_IF_ASYNC_IN_PROGRESS(self, execute);
     EXC_IF_TPC_PREPARED(self->conn, execute);
 
-    if (0 > _psyco_curs_execute(self, operation, vars, self->conn->async, 0)) {
+    if (0 > _psyco_curs_execute(self, operation, vars, self->conn->async_, 0)) {
         return NULL;
     }
 
@@ -1097,7 +1097,7 @@ psyco_curs_callproc(cursorObject *self, PyObject *args)
     }
 
     if (0 <= _psyco_curs_execute(
-            self, operation, pvals, self->conn->async, 0)) {
+            self, operation, pvals, self->conn->async_, 0)) {
         /* The dict case is outside DBAPI scope anyway, so simply return None */
         if (using_dict) {
             res = Py_None;

--- a/psycopg/replication_cursor_type.c
+++ b/psycopg/replication_cursor_type.c
@@ -68,7 +68,7 @@ psyco_repl_curs_start_replication_expert(replicationCursorObject *self,
     Dprintf("psyco_repl_curs_start_replication_expert: '%s'; decode: %ld",
         Bytes_AS_STRING(command), decode);
 
-    if (pq_execute(curs, Bytes_AS_STRING(command), conn->async,
+    if (pq_execute(curs, Bytes_AS_STRING(command), conn->async_,
             1 /* no_result */, 1 /* no_begin */) >= 0) {
         res = Py_None;
         Py_INCREF(res);


### PR DESCRIPTION
Please review it carefully, it builds and installs fine now, but I didn't do any runtime test.