### PR TITLE
Remove obsolete and incorrect FreeBSD version condition

### DIFF
--- a/psycopg/config.h
+++ b/psycopg/config.h
@@ -154,8 +154,7 @@ typedef unsigned __int64    uint64_t;
 #endif
 
 /* what's this, we have no round function either? */
-#if (defined(__FreeBSD__) && __FreeBSD_version < 503000) \
-    || (defined(_WIN32) && !defined(__GNUC__)) \
+#if (defined(_WIN32) && !defined(__GNUC__)) \
     || (defined(sun) || defined(__sun__)) \
         && (defined(__SunOS_5_8) || defined(__SunOS_5_9))
 


### PR DESCRIPTION
The FreeBSD-related condition which enables custom `round()` implementation is incorrect: one must include `<sys/param.h>` to get `__FreeBSD_version` value, and since it's not included here, the check succeeds while it shouldn't. Before it worked somehow, but since python 3.7 it results in conflicting declarations of `round()`. The condition is also no longer needed since FreeBSD 5.3 is unsupported for 12 years.

This change thus fixes build of psycopg with python 3.7 on FreeBSD.