### PR TITLE
Drop legacy distutils fallback in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,7 @@ import os
 import sys
 import re
 import subprocess
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils.sysconfig import get_python_inc
 from distutils.ccompiler import get_default_compiler


### PR DESCRIPTION
distutils is not recommended for use and unnecessary for modern Python
environments. Use only setuptools instead. From
https://docs.python.org/3/library/distutils.html:

> Most Python users will not want to use this module directly, but
> instead use the cross-version tools maintained by the Python Packaging
> Authority. In particular, setuptools is an enhanced alternative to
> distutils ...
>
> The recommended pip installer runs all setup.py scripts with
> setuptools, even if the script itself only imports distutils. Refer to
> the Python Packaging User Guide for more information.