### PR TITLE
Add documentation about the use of backslashes with LIKE

### DIFF
--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -224,7 +224,7 @@ argument of the `~cursor.execute()` method::
 Values containing backslashes and LIKE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Unlike in Python, the **backslash** (`\`) is not used as an escape
+Unlike in Python, the backslash (`\\`) is not used as an escape
 character *except* in patterns used with `LIKE` and `ILIKE` where they
 are needed to escape the `%` and `_` characters.
 

--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -221,7 +221,28 @@ argument of the `~cursor.execute()` method::
     >>> cur.execute(SQL, data) # Note: no % operator
 
 
+Values containing backslashes and LIKE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unlike in Python, the **backslash** (`\`) is not used as an escape
+character *except* in patterns used with `LIKE` and `ILIKE` where they
+are needed to escape the `%` and `_` characters.
+
+This can lead to confusing situations::
+
+   >>> path = r'C:\Users\Bobby.Tables'
+   >>> cur.execute('INSERT INTO mytable(path) VALUES (%s)', (path,))
+   >>> cur.execute('SELECT * FROM mytable WHERE path LIKE %s', (path,))
+   >>> cur.fetchall()
+   []
+
+The solution is to specify an `ESCAPE` character of `''` (empty string)
+in your `LIKE` query::
+
+   >>> cur.execute("SELECT * FROM mytable WHERE path LIKE %s ESCAPE ''", (path,))
+
+
+  
 .. index::
     single: Adaptation
     pair: Objects; Adaptation


### PR DESCRIPTION
As discussed in issue #785, add a note to the documentation about backslashes and LIKE/ILIKE.