### PR TITLE
Store WAL end pointer in the replication cursor

### DIFF
--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -481,6 +481,12 @@ The individual messages in the replication stream are represented by
         communication with the server (a data or keepalive message in either
         direction).
 
+    .. attribute:: wal_end
+
+       LSN position of the current end of WAL on the server at the
+       moment of last data or keepalive message received from the
+       server.
+
     An actual example of asynchronous operation might look like this::
 
       from select import select
@@ -500,7 +506,7 @@ The individual messages in the replication stream are represented by
               try:
                   sel = select([cur], [], [], max(0, timeout))
                   if not any(sel):
-                      cur.send_feedback()  # timed out, send keepalive message
+                      cur.send_feedback(flush_lsn=cur.wal_end)  # timed out, send keepalive message
               except InterruptedError:
                   pass  # recalculate timeout and continue
 

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -506,9 +506,22 @@ The individual messages in the replication stream are represented by
               try:
                   sel = select([cur], [], [], max(0, timeout))
                   if not any(sel):
-                      cur.send_feedback(flush_lsn=cur.wal_end)  # timed out, send keepalive message
+                      cur.send_feedback()  # timed out, send keepalive message
               except InterruptedError:
                   pass  # recalculate timeout and continue
+
+      .. warning::
+
+         The ``consume({msg})`` function will only be called when
+         there are new database writes on the server e.g. any DML or
+         DDL statement. Depending on your Postgres cluster
+         configuration this might cause the server to run out of disk
+         space if the writes are far apart. To prevent this from
+         happening you can use `~ReplicationCursor.wal_end` value to
+         periodically send feedback to the server to notify that your
+         replication client has received and processed all the
+         messages.
+
 
 .. index::
     pair: Cursor; Replication

--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -1712,6 +1712,8 @@ retry:
         (*msg)->data_start = data_start;
         (*msg)->wal_end    = wal_end;
         (*msg)->send_time  = send_time;
+
+        repl->wal_end = wal_end;
     }
     else if (buffer[0] == 'k') {
         /* Primary keepalive message: msgtype(1), walEnd(8), sendTime(8), reply(1) */
@@ -1739,7 +1741,6 @@ retry:
         goto exit;
     }
 
-    repl->wal_end = wal_end;
     ret = 0;
 
 exit:

--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -1721,6 +1721,10 @@ retry:
             goto exit;
         }
 
+        wal_end = fe_recvint64(buffer + 1);
+        Dprintf("pq_read_replication_message: wal_end="XLOGFMTSTR, XLOGFMTARGS(wal_end));
+        repl->wal_end = wal_end;
+
         reply = buffer[hdr];
         if (reply && pq_send_replication_feedback(repl, 0) < 0) {
             goto exit;
@@ -1735,6 +1739,7 @@ retry:
         goto exit;
     }
 
+    repl->wal_end = wal_end;
     ret = 0;
 
 exit:

--- a/psycopg/replication_cursor.h
+++ b/psycopg/replication_cursor.h
@@ -44,6 +44,8 @@ typedef struct replicationCursorObject {
     struct timeval last_io;       /* timestamp of the last exchange with the server */
     struct timeval keepalive_interval;   /* interval for keepalive messages in replication mode */
 
+    XLogRecPtr  wal_end;          /* WAL end pointer from the last exchange with the server */
+
     XLogRecPtr  write_lsn;        /* LSNs for replication feedback messages */
     XLogRecPtr  flush_lsn;
     XLogRecPtr  apply_lsn;

--- a/psycopg/replication_cursor.h
+++ b/psycopg/replication_cursor.h
@@ -44,11 +44,11 @@ typedef struct replicationCursorObject {
     struct timeval last_io;       /* timestamp of the last exchange with the server */
     struct timeval keepalive_interval;   /* interval for keepalive messages in replication mode */
 
-    XLogRecPtr  wal_end;          /* WAL end pointer from the last exchange with the server */
-
     XLogRecPtr  write_lsn;        /* LSNs for replication feedback messages */
     XLogRecPtr  flush_lsn;
     XLogRecPtr  apply_lsn;
+
+    XLogRecPtr  wal_end;          /* WAL end pointer from the last exchange with the server */
 } replicationCursorObject;
 
 

--- a/psycopg/replication_cursor_type.c
+++ b/psycopg/replication_cursor_type.c
@@ -231,6 +231,17 @@ psyco_repl_curs_get_io_timestamp(replicationCursorObject *self)
     return res;
 }
 
+/* object member list */
+
+#define OFFSETOF(x) offsetof(replicationCursorObject, x)
+
+static struct PyMemberDef replicationCursorObject_members[] = {
+    {"wal_end", T_ULONGLONG, OFFSETOF(wal_end), READONLY,
+        "LSN position of the current end of WAL on the server."},
+    {NULL}
+};
+
+
 /* object method list */
 
 static struct PyMethodDef replicationCursorObject_methods[] = {
@@ -261,6 +272,8 @@ replicationCursor_init(PyObject *obj, PyObject *args, PyObject *kwargs)
 
     self->consuming = 0;
     self->decode = 0;
+
+    self->wal_end = 0;
 
     self->write_lsn = 0;
     self->flush_lsn = 0;
@@ -311,7 +324,7 @@ PyTypeObject replicationCursorType = {
     0,          /*tp_iter*/
     0,          /*tp_iternext*/
     replicationCursorObject_methods, /*tp_methods*/
-    0,          /*tp_members*/
+    replicationCursorObject_members, /*tp_members*/
     replicationCursorObject_getsets, /*tp_getset*/
     &cursorType, /*tp_base*/
     0,          /*tp_dict*/

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -239,6 +239,7 @@ class AsyncReplicationTest(ReplicationTestCase):
         def consume(msg):
             # just check the methods
             "%s: %s" % (cur.io_timestamp, repr(msg))
+            "%s: %s" % (cur.wal_end, repr(msg))
 
             self.msg_count += 1
             if self.msg_count > 3:


### PR DESCRIPTION
We have a couple of logical replication daemons running that are built using the psycopg2 library. They're replicating different databases with very different load patterns. One of these DBs has lots of load 24/7 and another one that has writes only during the office hours. We're closely monitoring the replication lag to avoid running out of the disk space on each of the DB instances.

I observed that the replication lag grows pretty fast during the night hours on the DB that has writes only during the day. I'm not 100% sure why the DB is growing when there are no writes, but I assume that's due to RDS or our Postgres instance configuration. In any case, we started getting replication lag notifications so I started digging into the problem.

I found that the `pg_stat_replication` view gives us the last LSN that was sent to the logical replication client. If we know this LSN and if we know that there were no changes made to the tables we're interested in we could just confirm from the client using the `send_feedback` call that the server can recycle the WAL files. Otherwise we have to wait until there's a write to the DB that will trigger a `ReplicationMessage` that contains the `data_start`.

But I couldn't find any way to get the current WAL end in the psycopg2 `ReplicationCursor`. So this PR adds the current WAL end pointer the client has received from the server with this specific replication cursor.

Let me know if this makes sense and/or you would like this to be changed in any way...