### PR TITLE
add RETURNING clause support in execute_values function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ New features:
   structure (:ticket:`#782`).
 - `~psycopg2.sql.Identifier` can represent qualified names in SQL composition
   (:ticket:`#732`).
+- Added *fetch* parameter to `~psycopg2.extras.execute_values()` function
+  (:ticket:`813`).
 - Fixed adaptation of numeric subclasses such as `IntEnum` (:ticket:`591`).
 - `!str()` on `~psycopg2.extras.Range` produces a human-readable representation
   (:ticket:`#773`).

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -1023,6 +1023,8 @@ parameters.  By reducing the number of server roundtrips the performance can be
 .. autofunction:: execute_values
 
     .. versionadded:: 2.7
+    .. versionchanged:: 2.8
+        added the *fetch* parameter
 
 
 .. index::

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -1024,7 +1024,7 @@ parameters.  By reducing the number of server roundtrips the performance can be
 
     .. versionadded:: 2.7
     .. versionchanged:: 2.8
-        added the *fetch* parameter
+        added the *fetch* parameter.
 
 
 .. index::

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -1198,7 +1198,7 @@ def execute_batch(cur, sql, argslist, page_size=100):
         cur.execute(b";".join(sqls))
 
 
-def execute_values(cur, sql, argslist, template=None, page_size=100, fetch_result=False):
+def execute_values(cur, sql, argslist, template=None, page_size=100, fetch=False):
     '''Execute a statement using :sql:`VALUES` with a sequence of parameters.
 
     :param cur: the cursor to use to execute the query.
@@ -1229,7 +1229,7 @@ def execute_values(cur, sql, argslist, template=None, page_size=100, fetch_resul
         statement. If there are more items the function will execute more than
         one statement.
 
-    :param fetch_result: flag indicating that results of query execution should
+    :param fetch: flag indicating that results of query execution should
         be returned. Useful for queries with `RETURNING` clause
 
     .. __: https://www.postgresql.org/docs/current/static/queries-values.html
@@ -1278,10 +1278,10 @@ def execute_values(cur, sql, argslist, template=None, page_size=100, fetch_resul
             parts.append(b',')
         parts[-1:] = post
         cur.execute(b''.join(parts))
-        if fetch_result:
+        if fetch:
             result.extend(cur.fetchall())
 
-    if fetch_result:
+    if fetch:
         return result
 
 

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -1229,8 +1229,9 @@ def execute_values(cur, sql, argslist, template=None, page_size=100, fetch=False
         statement. If there are more items the function will execute more than
         one statement.
 
-    :param fetch: flag indicating that results of query execution should
-        be returned. Useful for queries with `RETURNING` clause
+    :param fetch: if `!True` return the query results into a list (like in a
+        `~cursor.fetchall()`).  Useful for queries with :sql:`RETURNING`
+        clause.
 
     .. __: https://www.postgresql.org/docs/current/static/queries-values.html
 

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -1268,7 +1268,7 @@ def execute_values(cur, sql, argslist, template=None, page_size=100, fetch=False
         sql = sql.encode(_ext.encodings[cur.connection.encoding])
     pre, post = _split_sql(sql)
 
-    result = []
+    result = [] if fetch else None
     for page in _paginate(argslist, page_size=page_size):
         if template is None:
             template = b'(' + b','.join([b'%s'] * len(page[0])) + b')'
@@ -1281,8 +1281,7 @@ def execute_values(cur, sql, argslist, template=None, page_size=100, fetch=False
         if fetch:
             result.extend(cur.fetchall())
 
-    if fetch:
-        return result
+    return result
 
 
 def _split_sql(sql):

--- a/tests/test_fast_executemany.py
+++ b/tests/test_fast_executemany.py
@@ -229,6 +229,15 @@ class TestExecuteValues(FastExecuteTestMixin, testutils.ConnectingTestCase):
         cur.execute("select id, data from testfast where id = 3")
         self.assertEqual(cur.fetchone(), (3, snowman))
 
+    def test_returning(self):
+        cur = self.conn.cursor()
+        result = psycopg2.extras.execute_values(cur,
+            "insert into testfast (id, val) values %s returning id",
+            ((i, i * 10) for i in range(25)),
+            page_size=10, fetch_many=True)
+        # result contains all returned pages
+        self.assertEqual([r[0] for r in result], list(range(25)))
+
     def test_invalid_sql(self):
         cur = self.conn.cursor()
         self.assertRaises(ValueError, psycopg2.extras.execute_values, cur,

--- a/tests/test_fast_executemany.py
+++ b/tests/test_fast_executemany.py
@@ -234,7 +234,7 @@ class TestExecuteValues(FastExecuteTestMixin, testutils.ConnectingTestCase):
         result = psycopg2.extras.execute_values(cur,
             "insert into testfast (id, val) values %s returning id",
             ((i, i * 10) for i in range(25)),
-            page_size=10, fetch_many=True)
+            page_size=10, fetch=True)
         # result contains all returned pages
         self.assertEqual([r[0] for r in result], list(range(25)))
 


### PR DESCRIPTION
We found it useful in our project to improve `psycopg.extras.execute_values` in such a way that it supports `RETURNING` clause of query being executed.