### PR TITLE
Remove Python 3.3 references from appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,10 +60,9 @@ init:
     - IF "%PYTHON_ARCH%"=="64" SET PYTHON=%PYTHON%-x64
 
       # Py 2.7 = VS Ver. 9.0  (VS 2008)
-      # Py 3.3, 3.4 = VS Ver. 10.0 (VS 2010)
-      # Py 3.5, 3.6 = VS Ver. 14.0 (VS 2015)
+      # Py 3.4 = VS Ver. 10.0 (VS 2010)
+      # Py 3.5, 3.6, 3.7 = VS Ver. 14.0 (VS 2015)
     - IF "%PYVER%"=="27" SET VS_VER=9.0
-    - IF "%PYVER%"=="33" SET VS_VER=10.0
     - IF "%PYVER%"=="34" SET VS_VER=10.0
     - IF "%PYVER%"=="35" SET VS_VER=14.0
     - IF "%PYVER%"=="36" SET VS_VER=14.0


### PR DESCRIPTION
Python 3.3 has been unsupported since
c2d082e896e7bcb81231603404e7d4789e56cf00.