### PR TITLE
Remove workarounds for unsupported libpq < 9.1

### DIFF
--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -398,12 +398,7 @@ exit:
 static PyObject*
 psyco_libpq_version(PyObject *self)
 {
-#if PG_VERSION_NUM >= 90100
     return PyInt_FromLong(PQlibVersion());
-#else
-    PyErr_SetString(NotSupportedError, "version discovery is not supported in libpq < 9.1");
-    return NULL;
-#endif
 }
 
 /* encrypt_password - Prepare the encrypted password form */

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -182,14 +182,12 @@ class TestQuotedString(ConnectingTestCase):
 
 
 class TestQuotedIdentifier(ConnectingTestCase):
-    @testutils.skip_before_libpq(9, 0)
     def test_identifier(self):
         from psycopg2.extensions import quote_ident
         self.assertEqual(quote_ident('blah-blah', self.conn), '"blah-blah"')
         self.assertEqual(quote_ident('quote"inside', self.conn), '"quote""inside"')
 
     @testutils.skip_before_postgres(8, 0)
-    @testutils.skip_before_libpq(9, 0)
     def test_unicode_ident(self):
         from psycopg2.extensions import quote_ident
         snowman = u"\u2603"


### PR DESCRIPTION
Per http://initd.org/psycopg/docs/install.html#prerequisites:

> PostgreSQL client library version from 9.1