### PR TITLE
Add project_urls to setup.py, with links to source and documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -639,4 +639,8 @@ setup(name="psycopg2",
       package_dir={'psycopg2': 'lib'},
       packages=['psycopg2'],
       cmdclass={'build_ext': psycopg_build_ext},
-      ext_modules=ext)
+      ext_modules=ext,
+      project_urls={
+          'Source': 'https://github.com/psycopg/psycopg2',
+          'Documentation': 'http://initd.org/psycopg/docs/',
+      })


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/psycopg2/), as well as including them in API responses to help automation tool find the source code for psycopg2. For example, see Django's [setup.py](https://github.com/django/django/blob/master/setup.py) and [PyPI listing](https://pypi.org/project/Django/).