### PR TITLE
Simplify have_(py|mx)datetime logic in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,6 @@ parser = configparser.ConfigParser()
 parser.read('setup.cfg')
 
 # Choose a datetime module
-have_pydatetime = True
 have_mxdatetime = False
 use_pydatetime = parser.getboolean('build_ext', 'use_pydatetime')
 
@@ -544,23 +543,10 @@ if mxincludedir.strip() and os.path.exists(mxincludedir):
     version_flags.append('mx')
 
 # now decide which package will be the default for date/time typecasts
-if have_pydatetime and (use_pydatetime or not have_mxdatetime):
+if use_pydatetime or not have_mxdatetime:
     define_macros.append(('PSYCOPG_DEFAULT_PYDATETIME', '1'))
-elif have_mxdatetime:
-    define_macros.append(('PSYCOPG_DEFAULT_MXDATETIME', '1'))
 else:
-    error_message = """\
-psycopg requires a datetime module:
-    mx.DateTime module not found
-    python datetime module not found
-
-Note that psycopg needs the module headers and not just the module
-itself. If you installed Python or mx.DateTime from a binary package
-you probably need to install its companion -dev or -devel package."""
-
-    for line in error_message.split("\n"):
-        sys.stderr.write("error: " + line)
-    sys.exit(1)
+    define_macros.append(('PSYCOPG_DEFAULT_MXDATETIME', '1'))
 
 # generate a nice version string to avoid confusion when users report bugs
 version_flags.append('pq3')     # no more a choice


### PR DESCRIPTION
`have_pydatetime` is always `True`. Its value never changes. All supported Python environments have the `datetime` module.

The "psycopg requires a datetime module" error case could never be reached as the setup always falls back to using the Python` datetime` module if `mx.DateTime` doesn't exist.