### PR TITLE
Remove unused import in test_errcodes

### DIFF
--- a/tests/test_errcodes.py
+++ b/tests/test_errcodes.py
@@ -26,12 +26,11 @@ import unittest
 from .testutils import ConnectingTestCase, slow, reload
 
 try:
+    # Python 2.7
     reload
 except NameError:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+    # Python 3
+    from importlib import reload
 
 from threading import Thread
 from psycopg2 import errorcodes


### PR DESCRIPTION
`reload()` is a builtin function in Python 2.7 and `importlib.reload()` is available on 3.4+. The fallback to `imp.reload()` is never used.