### PR TITLE
Move imports to the top of the module across tests

### DIFF
--- a/tests/test_async_keyword.py
+++ b/tests/test_async_keyword.py
@@ -24,6 +24,7 @@
 # License for more details.
 
 import time
+from select import select
 
 import psycopg2
 from psycopg2 import extras
@@ -205,7 +206,6 @@ class AsyncReplicationTest(ReplicationTestCase):
         self.assertRaises(psycopg2.ProgrammingError, cur.consume_stream, consume)
 
         def process_stream():
-            from select import select
             while True:
                 msg = cur.read_message()
                 if msg:

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -28,6 +28,9 @@ import pickle
 import psycopg2
 import psycopg2.extensions
 import unittest
+from datetime import date
+from decimal import Decimal
+from weakref import ref
 from .testutils import (ConnectingTestCase, skip_before_postgres,
     skip_if_no_getrefcount, slow, skip_if_no_superuser,
     skip_if_windows)
@@ -101,8 +104,6 @@ class CursorTests(ConnectingTestCase):
             cur.mogrify(u"SELECT %s;", (snowman,)))
 
     def test_mogrify_decimal_explodes(self):
-        from decimal import Decimal
-
         conn = self.conn
         cur = conn.cursor()
         self.assertEqual(b'SELECT 10.3;',
@@ -143,10 +144,8 @@ class CursorTests(ConnectingTestCase):
         self.assertEqual(42, curs.cast(20, '42'))
         self.assertAlmostEqual(3.14, curs.cast(700, '3.14'))
 
-        from decimal import Decimal
         self.assertEqual(Decimal('123.45'), curs.cast(1700, '123.45'))
 
-        from datetime import date
         self.assertEqual(date(2011, 1, 2), curs.cast(1082, '2011-01-02'))
         self.assertEqual("who am i?", curs.cast(705, 'who am i?'))  # unknown
 
@@ -166,7 +165,6 @@ class CursorTests(ConnectingTestCase):
         self.assertEqual("foofoo", curs2.cast(705, 'foo'))
 
     def test_weakref(self):
-        from weakref import ref
         curs = self.conn.cursor()
         w = ref(curs)
         del curs

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -26,6 +26,9 @@ import unittest
 from .testutils import ConnectingTestCase
 
 import psycopg2
+from psycopg2 import errors
+from psycopg2._psycopg import sqlstate_errors
+from psycopg2.errors import UndefinedTable
 
 
 class ErrorsTests(ConnectingTestCase):
@@ -36,14 +39,12 @@ class ErrorsTests(ConnectingTestCase):
         except psycopg2.Error as exc:
             e = exc
 
-        from psycopg2.errors import UndefinedTable
         self.assert_(isinstance(e, UndefinedTable), type(e))
         self.assert_(isinstance(e, self.conn.ProgrammingError))
 
     def test_exception_class_fallback(self):
         cur = self.conn.cursor()
 
-        from psycopg2._psycopg import sqlstate_errors
         x = sqlstate_errors.pop('42P01')
         try:
             cur.execute("select * from nonexist")
@@ -55,17 +56,12 @@ class ErrorsTests(ConnectingTestCase):
         self.assertEqual(type(e), self.conn.ProgrammingError)
 
     def test_lookup(self):
-        from psycopg2 import errors
-
         self.assertIs(errors.lookup('42P01'), errors.UndefinedTable)
 
         with self.assertRaises(KeyError):
             errors.lookup('XXXXX')
 
     def test_has_base_exceptions(self):
-        import psycopg2
-        from psycopg2 import errors
-
         excs = []
         for n in dir(psycopg2):
             obj = getattr(psycopg2, n)

--- a/tests/test_extras_dictcursor.py
+++ b/tests/test_extras_dictcursor.py
@@ -16,10 +16,14 @@
 
 import time
 import pickle
-from datetime import timedelta
-import psycopg2
-import psycopg2.extras
 import unittest
+from datetime import timedelta
+
+import psycopg2
+from psycopg2.compat import lru_cache
+import psycopg2.extras
+from psycopg2.extras import NamedTupleConnection, NamedTupleCursor
+
 from .testutils import ConnectingTestCase, skip_before_postgres, \
     skip_before_python, skip_from_python
 
@@ -358,7 +362,6 @@ class ExtrasDictCursorRealTests(_DictCursorBase):
 class NamedTupleCursorTest(ConnectingTestCase):
     def setUp(self):
         ConnectingTestCase.setUp(self)
-        from psycopg2.extras import NamedTupleConnection
 
         self.conn = self.connect(connection_factory=NamedTupleConnection)
         curs = self.conn.cursor()
@@ -495,7 +498,6 @@ class NamedTupleCursorTest(ConnectingTestCase):
 
     def test_minimal_generation(self):
         # Instrument the class to verify it gets called the minimum number of times.
-        from psycopg2.extras import NamedTupleCursor
         f_orig = NamedTupleCursor._make_nt
         calls = [0]
 
@@ -591,9 +593,6 @@ class NamedTupleCursorTest(ConnectingTestCase):
         self.assert_(type(r1) is not type(r2))
 
     def test_max_cache(self):
-        from psycopg2.extras import NamedTupleCursor
-        from psycopg2.compat import lru_cache
-
         old_func = NamedTupleCursor._cached_make_nt
         NamedTupleCursor._cached_make_nt = \
             lru_cache(8)(NamedTupleCursor._do_make_nt)

--- a/tests/test_fast_executemany.py
+++ b/tests/test_fast_executemany.py
@@ -22,6 +22,7 @@ import unittest
 import psycopg2
 import psycopg2.extras
 import psycopg2.extensions as ext
+from psycopg2 import sql
 
 
 class TestPaginate(unittest.TestCase):
@@ -84,7 +85,6 @@ class TestExecuteBatch(FastExecuteTestMixin, testutils.ConnectingTestCase):
         self.assertEqual(cur.fetchall(), [(i, i * 10) for i in range(1000)])
 
     def test_composed(self):
-        from psycopg2 import sql
         cur = self.conn.cursor()
         psycopg2.extras.execute_batch(cur,
             sql.SQL("insert into {0} (id, val) values (%s, %s)")
@@ -181,7 +181,6 @@ class TestExecuteValues(FastExecuteTestMixin, testutils.ConnectingTestCase):
         self.assertEqual(cur.fetchall(), [(i, i * 10) for i in range(1000)])
 
     def test_composed(self):
-        from psycopg2 import sql
         cur = self.conn.cursor()
         psycopg2.extras.execute_values(cur,
             sql.SQL("insert into {0} (id, val) values %s")

--- a/tests/test_green.py
+++ b/tests/test_green.py
@@ -22,10 +22,12 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
+import select
 import unittest
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
+from psycopg2.extensions import POLL_OK, POLL_READ, POLL_WRITE
 
 from .testutils import ConnectingTestCase, skip_before_postgres, slow
 
@@ -131,9 +133,6 @@ class CallbackErrorTestCase(ConnectingTestCase):
 
     def crappy_callback(self, conn):
         """green callback failing after `self.to_error` time it is called"""
-        import select
-        from psycopg2.extensions import POLL_OK, POLL_READ, POLL_WRITE
-
         while True:
             if self.to_error is not None:
                 self.to_error -= 1

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -22,9 +22,11 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
+import gc
 import os
 import sys
 from subprocess import Popen
+from weakref import ref
 
 import unittest
 from .testutils import (skip_before_postgres,
@@ -190,9 +192,6 @@ class ExceptionsTestCase(ConnectingTestCase):
         self.assertEqual(e.diag.severity, 'ERROR')
 
     def test_diagnostics_life(self):
-        import gc
-        from weakref import ref
-
         def tmp():
             cur = self.conn.cursor()
             try:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -23,9 +23,11 @@
 # License for more details.
 
 import unittest
+from collections import deque
 
 import psycopg2
 from psycopg2 import extensions
+from psycopg2.extensions import Notify
 from .testutils import ConnectingTestCase, slow
 from .testconfig import dsn
 
@@ -163,7 +165,6 @@ conn.close()
 
     @slow
     def test_notify_deque(self):
-        from collections import deque
         self.autocommit(self.conn)
         self.conn.notifies = deque()
         self.listen('foo')
@@ -209,14 +210,12 @@ conn.close()
                 self.assertEqual((n1 != n2), (d1 != d2))
 
     def test_compare_tuple(self):
-        from psycopg2.extensions import Notify
         self.assertEqual((10, 'foo'), Notify(10, 'foo'))
         self.assertEqual((10, 'foo'), Notify(10, 'foo', 'bar'))
         self.assertNotEqual((10, 'foo'), Notify(20, 'foo'))
         self.assertNotEqual((10, 'foo'), Notify(10, 'bar'))
 
     def test_hash(self):
-        from psycopg2.extensions import Notify
         self.assertEqual(hash((10, 'foo')), hash(Notify(10, 'foo')))
         self.assertNotEqual(hash(Notify(10, 'foo', 'bar')),
             hash(Notify(10, 'foo')))

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -29,6 +29,7 @@ from .testutils import ConnectingTestCase, unichr
 
 import psycopg2
 import psycopg2.extensions
+from psycopg2.extensions import adapt, quote_ident
 
 
 class QuotingTestCase(ConnectingTestCase):
@@ -194,13 +195,11 @@ class TestQuotedString(ConnectingTestCase):
 
 class TestQuotedIdentifier(ConnectingTestCase):
     def test_identifier(self):
-        from psycopg2.extensions import quote_ident
         self.assertEqual(quote_ident('blah-blah', self.conn), '"blah-blah"')
         self.assertEqual(quote_ident('quote"inside', self.conn), '"quote""inside"')
 
     @testutils.skip_before_postgres(8, 0)
     def test_unicode_ident(self):
-        from psycopg2.extensions import quote_ident
         snowman = u"\u2603"
         quoted = '"' + snowman + '"'
         if sys.version_info[0] < 3:
@@ -211,7 +210,6 @@ class TestQuotedIdentifier(ConnectingTestCase):
 
 class TestStringAdapter(ConnectingTestCase):
     def test_encoding_default(self):
-        from psycopg2.extensions import adapt
         a = adapt("hello")
         self.assertEqual(a.encoding, 'latin1')
         self.assertEqual(a.getquoted(), b"'hello'")
@@ -223,7 +221,6 @@ class TestStringAdapter(ConnectingTestCase):
         # self.assertEqual(adapt(egrave).getquoted(), "'\xe8'")
 
     def test_encoding_error(self):
-        from psycopg2.extensions import adapt
         snowman = u"\u2603"
         a = adapt(snowman)
         self.assertRaises(UnicodeEncodeError, a.getquoted)
@@ -232,7 +229,6 @@ class TestStringAdapter(ConnectingTestCase):
         # Note: this works-ish mostly in case when the standard db connection
         # we test with is utf8, otherwise the encoding chosen by PQescapeString
         # may give bad results.
-        from psycopg2.extensions import adapt
         snowman = u"\u2603"
         a = adapt(snowman)
         a.encoding = 'utf8'
@@ -240,7 +236,6 @@ class TestStringAdapter(ConnectingTestCase):
         self.assertEqual(a.getquoted(), b"'\xe2\x98\x83'")
 
     def test_connection_wins_anyway(self):
-        from psycopg2.extensions import adapt
         snowman = u"\u2603"
         a = adapt(snowman)
         a.encoding = 'latin9'

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -22,7 +22,10 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 # License for more details.
 
+from select import select
+
 import psycopg2
+from psycopg2 import sql
 from psycopg2.extras import (
     PhysicalReplicationConnection, LogicalReplicationConnection, StopReplication)
 
@@ -141,7 +144,6 @@ class ReplicationTest(ReplicationTestCase):
     @skip_before_postgres(9, 4)  # slots require 9.4
     @skip_repl_if_green
     def test_start_replication_expert_sql(self):
-        from psycopg2 import sql
         conn = self.repl_connect(connection_factory=LogicalReplicationConnection)
         if conn is None:
             return
@@ -252,7 +254,6 @@ class AsyncReplicationTest(ReplicationTestCase):
         self.assertRaises(psycopg2.ProgrammingError, cur.consume_stream, consume)
 
         def process_stream():
-            from select import select
             while True:
                 msg = cur.read_message()
                 if msg:

--- a/tests/test_types_basic.py
+++ b/tests/test_types_basic.py
@@ -33,6 +33,7 @@ from .testutils import ConnectingTestCase, long
 
 import psycopg2
 from psycopg2.compat import text_type
+from psycopg2.extensions import AsIs, adapt, register_adapter
 
 
 class TypesBasicTests(ConnectingTestCase):
@@ -424,8 +425,6 @@ class TypesBasicTests(ConnectingTestCase):
 
 class AdaptSubclassTest(unittest.TestCase):
     def test_adapt_subtype(self):
-        from psycopg2.extensions import adapt
-
         class Sub(str):
             pass
         s1 = "hel'lo"
@@ -433,8 +432,6 @@ class AdaptSubclassTest(unittest.TestCase):
         self.assertEqual(adapt(s1).getquoted(), adapt(s2).getquoted())
 
     def test_adapt_most_specific(self):
-        from psycopg2.extensions import adapt, register_adapter, AsIs
-
         class A(object):
             pass
 
@@ -454,8 +451,6 @@ class AdaptSubclassTest(unittest.TestCase):
 
     @testutils.skip_from_python(3)
     def test_no_mro_no_joy(self):
-        from psycopg2.extensions import adapt, register_adapter, AsIs
-
         class A:
             pass
 
@@ -470,8 +465,6 @@ class AdaptSubclassTest(unittest.TestCase):
 
     @testutils.skip_before_python(3)
     def test_adapt_subtype_3(self):
-        from psycopg2.extensions import adapt, register_adapter, AsIs
-
         class A:
             pass
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -33,7 +33,10 @@ import unittest
 from functools import wraps
 from ctypes.util import find_library
 from .testconfig import dsn, repl_dsn
+from psycopg2 import ProgrammingError
 from psycopg2.compat import text_type
+
+from .testconfig import green
 
 # Python 2/3 compatibility
 
@@ -241,7 +244,6 @@ def skip_if_tpc_disabled(f):
     """Skip a test if the server has tpc support disabled."""
     @wraps(f)
     def skip_if_tpc_disabled_(self):
-        from psycopg2 import ProgrammingError
         cnn = self.connect()
         cur = cnn.cursor()
         try:
@@ -368,7 +370,6 @@ def skip_if_no_superuser(f):
     """Skip a test if the database user running the test is not a superuser"""
     @wraps(f)
     def skip_if_no_superuser_(self):
-        from psycopg2 import ProgrammingError
         try:
             return f(self)
         except ProgrammingError as e:
@@ -383,7 +384,6 @@ def skip_if_no_superuser(f):
 
 def skip_if_green(reason):
     def skip_if_green_(cls):
-        from .testconfig import green
         decorator = unittest.skipIf(green, reason)
         return decorator(cls)
     return skip_if_green_


### PR DESCRIPTION
Allows removing many duplicate imports and better follows PEP8 guidelines:

https://www.python.org/dev/peps/pep-0008/#imports

> Imports are always put at the top of the file, just after any module
> comments and docstrings, and before module globals and constants.