### PR TITLE
Fix invalid exception handler: `except e:`

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -387,8 +387,6 @@ class ParseDsnTestCase(ConnectingTestCase):
             raised = True
             self.assertTrue(str(e).find('secret') < 0,
                             "DSN was not exposed in error message")
-        except e:
-            self.fail("unexpected error condition: " + repr(e))
         self.assertTrue(raised, "ProgrammingError raised due to invalid DSN")
 
     @skip_before_libpq(9, 2)
@@ -405,8 +403,6 @@ class ParseDsnTestCase(ConnectingTestCase):
             raised = True
             self.assertTrue(str(e).find('secret') < 0,
                             "URI was not exposed in error message")
-        except e:
-            self.fail("unexpected error condition: " + repr(e))
         self.assertTrue(raised, "ProgrammingError raised due to invalid URI")
 
     def test_unicode_value(self):


### PR DESCRIPTION
Fixes flake8 warning:

    ./tests/test_connection.py:390:16: F821 undefined name 'e'
    ./tests/test_connection.py:391:61: F821 undefined name 'e'
    ./tests/test_connection.py:408:16: F821 undefined name 'e'
    ./tests/test_connection.py:409:61: F821 undefined name 'e'

In the event of an unexpected error, let the exception bubble up the stack for a more informative test failure message.