### PR TITLE
Require OpenSSL 1.1.x library names on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -366,8 +366,14 @@ For further information please check the 'doc/src/install.rst' file (also at
                     self.library_dirs.append(os.path.join(path, "ms"))
                     break
             if self.have_ssl:
-                self.libraries.append("libeay32")
-                self.libraries.append("ssleay32")
+                # OpenSSL >= 1.1.0 has different library names from 1.0.x
+                # libeay32 became libcrypto
+                # ssleay32 became libssl
+                # We require OpenSSL 1.1.x, to avoid nasty issues
+                # with threads, see:
+                # https://github.com/psycopg/psycopg2/issues/543
+                self.libraries.append("libcrypto")
+                self.libraries.append("libssl")
                 self.libraries.append("crypt32")
                 self.libraries.append("user32")
                 self.libraries.append("gdi32")


### PR DESCRIPTION
We believe that OpenSSL 1.1.x will fix the threading issues previously
reported with binary builds:

https://github.com/psycopg/psycopg2/issues/543

Require the OpenSSL 1.1.x Windows library names.

See: https://github.com/psycopg/psycopg2-wheels/pull/8