### PR TITLE
Smart replication feedback

### DIFF
--- a/doc/src/advanced.rst
+++ b/doc/src/advanced.rst
@@ -552,8 +552,7 @@ value greater than zero in ``postgresql.conf`` (these changes require a server
 restart).  Create a database ``psycopg2_test``.
 
 Then run the following code to quickly try the replication support out.  This
-is not production code -- it has no error handling, it sends feedback too
-often, etc. -- and it's only intended as a simple demo of logical
+is not production code -- it's only intended as a simple demo of logical
 replication::
 
   from __future__ import print_function

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -345,6 +345,9 @@ The individual messages in the replication stream are represented by
         `read_message()` in case of :ref:`asynchronous connection
         <async-support>`.
 
+        .. versionchanged:: 2.8.3
+            added the *status_interval* parameter.
+
         .. |START_REPLICATION| replace:: :sql:`START_REPLICATION`
         .. _START_REPLICATION: https://www.postgresql.org/docs/current/static/protocol-replication.html
 
@@ -358,6 +361,9 @@ The individual messages in the replication stream are represented by
         :param decode: a flag indicating that unicode conversion should be
             performed on messages received from the server.
         :param status_interval: time between feedback packets sent to the server
+
+        .. versionchanged:: 2.8.3
+            added the *status_interval* parameter.
 
 
     .. method:: consume_stream(consume, keepalive_interval=None)
@@ -417,6 +423,9 @@ The individual messages in the replication stream are represented by
             retains all the WAL segments that might be needed to stream the
             changes via all of the currently open replication slots.
 
+        .. versionchanged:: 2.8.3
+            changed the default value of the *keepalive_interval* parameter to `!None`.
+
     .. method:: send_feedback(write_lsn=0, flush_lsn=0, apply_lsn=0, reply=False, force=False)
 
         :param write_lsn: a LSN position up to which the client has written the data locally
@@ -437,6 +446,9 @@ The individual messages in the replication stream are represented by
         just update internal structures without sending the feedback message
         to the server. The library sends feedback message automatically
         when *status_interval* timeout is reached.
+
+        .. versionchanged:: 2.8.3
+            added the *force* parameter.
 
     Low-level replication cursor methods for :ref:`asynchronous connection
     <async-support>` operation.
@@ -492,6 +504,8 @@ The individual messages in the replication stream are represented by
 
         A `~datetime` object representing the timestamp at the moment when
         the last feedback message sent to the server.
+
+        .. versionadded:: 2.8.3
 
     .. attribute:: wal_end
 

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -360,7 +360,7 @@ The individual messages in the replication stream are represented by
         :param status_interval: time between feedback packets sent to the server
 
 
-    .. method:: consume_stream(consume, keepalive_interval=10)
+    .. method:: consume_stream(consume, keepalive_interval=None)
 
         :param consume: a callable object with signature :samp:`consume({msg})`
         :param keepalive_interval: interval (in seconds) to send keepalive
@@ -386,6 +386,9 @@ The individual messages in the replication stream are represented by
         This method also sends feedback messages to the server every
         *keepalive_interval* (in seconds). The value of this parameter must
         be set to at least 1 second, but it can have a fractional part.
+        If the *keepalive_interval* is not specified, the value of
+        *status_interval* specified in the `start_replication()` or
+        `start_replication_expert()` will be used.
 
         The client must confirm every processed message by calling
         `send_feedback()` method on the corresponding replication cursor. A

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -561,7 +561,7 @@ class ReplicationCursor(_replicationCursor):
         self.execute(command)
 
     def start_replication(self, slot_name=None, slot_type=None, start_lsn=0,
-                          timeline=0, options=None, decode=False):
+                          timeline=0, options=None, decode=False, status_interval=10):
         """Start replication stream."""
 
         command = "START_REPLICATION "
@@ -615,7 +615,7 @@ class ReplicationCursor(_replicationCursor):
                 command += "%s %s" % (quote_ident(k, self), _A(str(v)))
             command += ")"
 
-        self.start_replication_expert(command, decode=decode)
+        self.start_replication_expert(command, decode=decode, status_interval=status_interval)
 
     # allows replication cursors to be used in select.select() directly
     def fileno(self):

--- a/psycopg/pqpath.h
+++ b/psycopg/pqpath.h
@@ -65,8 +65,7 @@ HIDDEN int pq_execute_command_locked(connectionObject *conn, const char *query,
 RAISES HIDDEN void pq_complete_error(connectionObject *conn);
 
 /* replication protocol support */
-HIDDEN int pq_copy_both(replicationCursorObject *repl, PyObject *consumer,
-                        double keepalive_interval);
+HIDDEN int pq_copy_both(replicationCursorObject *repl, PyObject *consumer);
 HIDDEN int pq_read_replication_message(replicationCursorObject *repl,
                                        replicationMessageObject **msg);
 HIDDEN int pq_send_replication_feedback(replicationCursorObject *repl, int reply_requested);

--- a/psycopg/replication_cursor.h
+++ b/psycopg/replication_cursor.h
@@ -42,13 +42,16 @@ typedef struct replicationCursorObject {
     int         decode:1;         /* if we should use character decoding on the messages */
 
     struct timeval last_io;       /* timestamp of the last exchange with the server */
-    struct timeval keepalive_interval;   /* interval for keepalive messages in replication mode */
+    struct timeval status_interval;   /* time between status packets sent to the server */
 
     XLogRecPtr  write_lsn;        /* LSNs for replication feedback messages */
     XLogRecPtr  flush_lsn;
     XLogRecPtr  apply_lsn;
 
     XLogRecPtr  wal_end;          /* WAL end pointer from the last exchange with the server */
+
+    XLogRecPtr  last_msg_data_start; /* WAL pointer to the last non-keepalive message from the server */
+    struct timeval last_feedback; /* timestamp of the last feedback message to the server */
 } replicationCursorObject;
 
 

--- a/psycopg/replication_cursor_type.c
+++ b/psycopg/replication_cursor_type.c
@@ -152,7 +152,7 @@ consume_stream(replicationCursorObject *self,
     CLEARPGRES(curs->pgres);
 
     self->consuming = 1;
-    if (keepalive_interval >= 1) {
+    if (keepalive_interval > 0) {
         set_status_interval(self, keepalive_interval);
     }
 

--- a/psycopg/replication_cursor_type.c
+++ b/psycopg/replication_cursor_type.c
@@ -38,8 +38,14 @@
 #include "datetime.h"
 
 
+static void set_status_interval(replicationCursorObject *self, double status_interval)
+{
+    self->status_interval.tv_sec  = (int)status_interval;
+    self->status_interval.tv_usec = (long)((status_interval - self->status_interval.tv_sec)*1.0e6);
+}
+
 #define start_replication_expert_doc \
-"start_replication_expert(command, decode=False) -- Start replication with a given command."
+"start_replication_expert(command, decode=False, status_interval=10) -- Start replication with a given command."
 
 static PyObject *
 start_replication_expert(replicationCursorObject *self,
@@ -49,10 +55,12 @@ start_replication_expert(replicationCursorObject *self,
     connectionObject *conn = self->cur.conn;
     PyObject *res = NULL;
     PyObject *command = NULL;
+    double status_interval = 10;
     long int decode = 0;
-    static char *kwlist[] = {"command", "decode", NULL};
+    static char *kwlist[] = {"command", "decode", "status_interval", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|l", kwlist, &command, &decode)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|ld", kwlist,
+                                     &command, &decode, &status_interval)) {
         return NULL;
     }
 
@@ -64,6 +72,11 @@ start_replication_expert(replicationCursorObject *self,
         goto exit;
     }
 
+    if (status_interval < 1.0) {
+        psyco_set_error(ProgrammingError, curs, "status_interval must be >= 1 (sec)");
+        return NULL;
+    }
+
     Dprintf("start_replication_expert: '%s'; decode: %ld",
         Bytes_AS_STRING(command), decode);
 
@@ -72,6 +85,7 @@ start_replication_expert(replicationCursorObject *self,
         res = Py_None;
         Py_INCREF(res);
 
+        set_status_interval(self, status_interval);
         self->decode = decode;
         gettimeofday(&self->last_io, NULL);
     }
@@ -124,8 +138,9 @@ consume_stream(replicationCursorObject *self,
     CLEARPGRES(curs->pgres);
 
     self->consuming = 1;
+    set_status_interval(self, keepalive_interval);
 
-    if (pq_copy_both(self, consume, keepalive_interval) >= 0) {
+    if (pq_copy_both(self, consume) >= 0) {
         res = Py_None;
         Py_INCREF(res);
     }
@@ -159,7 +174,7 @@ read_message(replicationCursorObject *self, PyObject *dummy)
 }
 
 #define send_feedback_doc \
-"send_feedback(write_lsn=0, flush_lsn=0, apply_lsn=0, reply=False) -- Try sending a replication feedback message to the server and optionally request a reply."
+"send_feedback(write_lsn=0, flush_lsn=0, apply_lsn=0, reply=False, force=False) -- Update a replication feedback, optionally request a reply or force sending a feedback message regardless of the timeout."
 
 static PyObject *
 send_feedback(replicationCursorObject *self,
@@ -167,13 +182,13 @@ send_feedback(replicationCursorObject *self,
 {
     cursorObject *curs = &self->cur;
     XLogRecPtr write_lsn = 0, flush_lsn = 0, apply_lsn = 0;
-    int reply = 0;
-    static char* kwlist[] = {"write_lsn", "flush_lsn", "apply_lsn", "reply", NULL};
+    int reply = 0, force = 0;
+    static char* kwlist[] = {"write_lsn", "flush_lsn", "apply_lsn", "reply", "force", NULL};
 
     EXC_IF_CURS_CLOSED(curs);
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|KKKi", kwlist,
-                                     &write_lsn, &flush_lsn, &apply_lsn, &reply)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|KKKii", kwlist,
+                                     &write_lsn, &flush_lsn, &apply_lsn, &reply, &force)) {
         return NULL;
     }
 
@@ -186,7 +201,7 @@ send_feedback(replicationCursorObject *self,
     if (apply_lsn > self->apply_lsn)
         self->apply_lsn = apply_lsn;
 
-    if (pq_send_replication_feedback(self, reply) < 0) {
+    if ((force || reply) && pq_send_replication_feedback(self, reply) < 0) {
         return NULL;
     }
 
@@ -228,6 +243,28 @@ repl_curs_get_io_timestamp(replicationCursorObject *self)
     return res;
 }
 
+#define repl_curs_feedback_timestamp_doc \
+"feedback_timestamp -- the timestamp of the latest feedback message sent to the server"
+
+static PyObject *
+repl_curs_get_feedback_timestamp(replicationCursorObject *self)
+{
+    cursorObject *curs = &self->cur;
+    PyObject *tval, *res = NULL;
+    double seconds;
+
+    EXC_IF_CURS_CLOSED(curs);
+
+    seconds = self->last_feedback.tv_sec + self->last_feedback.tv_usec / 1.0e6;
+
+    tval = Py_BuildValue("(d)", seconds);
+    if (tval) {
+        res = PyDateTime_FromTimestamp(tval);
+        Py_DECREF(tval);
+    }
+    return res;
+}
+
 /* object member list */
 
 #define OFFSETOF(x) offsetof(replicationCursorObject, x)
@@ -259,6 +296,9 @@ static struct PyGetSetDef replicationCursorObject_getsets[] = {
     { "io_timestamp",
       (getter)repl_curs_get_io_timestamp, NULL,
       repl_curs_io_timestamp_doc, NULL },
+    { "feedback_timestamp",
+      (getter)repl_curs_get_feedback_timestamp, NULL,
+      repl_curs_feedback_timestamp_doc, NULL },
     {NULL}
 };
 

--- a/psycopg/solaris_support.h
+++ b/psycopg/solaris_support.h
@@ -35,6 +35,13 @@
 extern HIDDEN void timeradd(struct timeval *a, struct timeval *b, struct timeval *c);
 extern HIDDEN void timersub(struct timeval *a, struct timeval *b, struct timeval *c);
 #endif
+
+#ifndef timercmp
+#define timercmp(a, b, cmp)          \
+  (((a)->tv_sec == (b)->tv_sec) ?    \
+   ((a)->tv_usec cmp (b)->tv_usec) : \
+   ((a)->tv_sec  cmp (b)->tv_sec))
+#endif
 #endif
 
 #endif /* !defined(PSYCOPG_SOLARIS_SUPPORT_H) */

--- a/psycopg/win32_support.h
+++ b/psycopg/win32_support.h
@@ -43,6 +43,13 @@ extern HIDDEN void timeradd(struct timeval *a, struct timeval *b, struct timeval
 #endif
 
 extern HIDDEN void timersub(struct timeval *a, struct timeval *b, struct timeval *c);
+
+#ifndef timercmp
+#define timercmp(a, b, cmp)          \
+  (((a)->tv_sec == (b)->tv_sec) ?    \
+   ((a)->tv_usec cmp (b)->tv_usec) : \
+   ((a)->tv_sec  cmp (b)->tv_sec))
+#endif
 #endif
 
 #endif /* !defined(PSYCOPG_WIN32_SUPPORT_H) */

--- a/tests/test_async_keyword.py
+++ b/tests/test_async_keyword.py
@@ -194,6 +194,7 @@ class AsyncReplicationTest(ReplicationTestCase):
         def consume(msg):
             # just check the methods
             "%s: %s" % (cur.io_timestamp, repr(msg))
+            "%s: %s" % (cur.feedback_timestamp, repr(msg))
 
             self.msg_count += 1
             if self.msg_count > 3:


### PR DESCRIPTION
This commit makes psycopg2 responsible for sending the status update (feedback) messages to the server regardless of whether a synchronous or asynchronous connection is used.

Feedback is sent every *status_interval* (default value is 10) seconds, which could be configured by passing a corresponding parameter to the `start_replication()` or `start_replication_expert()` methods.
The actual feedback message is sent by the `pq_read_replication_message()` when the *status_interval* timeout is reached.

The default behavior of the `send_feedback()` method is changed. It doesn't send a feedback message on every call anymore but just updates internal structures. There is still a way to *force* sending a message if *force* or *reply* parameters are set.

The new approach has certain advantages:
1. The client can simply call the `send_feedback()` for every processed message and the library will take care of not overwhelming the server. Actually, in the synchronous mode it is even mandatory to confirm every processed message.
2. The library tracks internally the pointer of the last received message which is not keepalive. If the client confirmed the last message and after that server sends only keepalives with increasing *wal_end*, the library can safely move forward *flush* position to the *wal_end* and later automatically report it to the server.

Reporting of the *wal_end* received from keepalive messages is very important. Not doing so casing:
1. Excessive disk usage, because the replication slot prevents from WAL being cleaned up.
2. The smart and fast shutdown of the server could last indefinitely because walsender waits until the client report *flush* position equal to the *wal_end*.

The new way of sending status update (feedback) messages is inspired by reading the source code of the `pg_recvlogical` and [pgjdbc](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java).

This implementation is only extending the existing API and therefore should not break any of the existing code.