### PR TITLE
Fix namedtuple cache

### DIFF
--- a/tests/test_extras_dictcursor.py
+++ b/tests/test_extras_dictcursor.py
@@ -639,7 +639,7 @@ class NamedTupleCursorTest(ConnectingTestCase):
     def test_max_cache(self):
         old_func = NamedTupleCursor._cached_make_nt
         NamedTupleCursor._cached_make_nt = \
-            lru_cache(8)(NamedTupleCursor._do_make_nt)
+            lru_cache(8)(NamedTupleCursor._cached_make_nt.__wrapped__)
         try:
             recs = []
             curs = self.conn.cursor()


### PR DESCRIPTION
I've finally gotten around to testing @dvarrazzo's solution to #838. Unfortunately it doesn't fully work.

The problem is that the `lru_cache` function was used to wrap a non-static method, so it receives `self` as first argument instead of only receiving `key` as intended, and since `self` (the cursor) isn't always the same object, the cache misses.

The fix is a little akward because the `lru_cache` decorator doesn't play well with `classmethod` and `staticmethod` (it took me a while to find a way that works).