### PR TITLE
Take libdir from pg_config --ldflags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -409,6 +409,11 @@ For further information please check the 'doc/src/install.rst' file (also at
 
         try:
             self.library_dirs.append(pg_config_helper.query("libdir"))
+            # Parse LD_FLAGS: turn "-L/foo -L/bar -Wxyz" into ["/foo", "/bar"]
+            ld_flags = pg_config_helper.query("ldflags")
+            ld_flags = filter(lambda x: x.startswith('-L'), ld_flags.split(' '))
+            ld_flags = map(lambda x: x[2:], ld_flags)
+            self.library_dirs.extend(ld_flags)
             self.include_dirs.append(pg_config_helper.query("includedir"))
             self.include_dirs.append(pg_config_helper.query("includedir-server"))
             pgversion = pg_config_helper.query("version").split()[1]


### PR DESCRIPTION
On OS X with OpenSSL installed via brew, `-lssl` is not found
during the linker stage. This can be remedied by correctly taking into
account the build-time settings for PostgreSQL.

Since the format is incompatible, this commit introduces some string
parsing to retrieve the directories referenced in the linker call.

So, this commit fixes the build on OS X for me with PostgreSQL and OpenSSL installed from brew.