### PR TITLE
Implement keeping pooled connections open

### DIFF
--- a/doc/src/pool.rst
+++ b/doc/src/pool.rst
@@ -12,13 +12,22 @@ Creating new PostgreSQL connections can be an expensive operation.  This
 module offers a few pure Python classes implementing simple connection pooling
 directly in the client application.
 
-.. class:: AbstractConnectionPool(minconn, maxconn, \*args, \*\*kwargs)
+.. class:: AbstractConnectionPool(minconn, maxconn, \*args, idle_timeout=0, \*\*kwargs)
 
     Base class implementing generic key-based pooling code.
 
     New *minconn* connections are created automatically. The pool will support
     a maximum of about *maxconn* connections.  *\*args* and *\*\*kwargs* are
     passed to the `~psycopg2.connect()` function.
+
+    Connections are kept in the pool for at most *idle_timeout* seconds. There
+    are two special values: zero means that connections are always immediately
+    closed upon their return to the pool; `None` means that connections are kept
+    indefinitely (leaving the server in charge of closing idle connections). The
+    current default value is zero because it replicates the behavior of previous
+    versions, however the default value may be changed in a future release.
+
+    .. versionadded:: 2.9 the *idle_timeout* argument.
 
     The following methods are expected to be implemented by subclasses:
 
@@ -44,6 +53,14 @@ directly in the client application.
         Note that all the connections are closed, including ones
         eventually in use by the application.
 
+    .. method:: prune
+
+        Drop all expired connections from the pool.
+
+        You can call this method periodically to clean up the pool.
+
+        .. versionadded:: 2.9
+
 
 The following classes are `AbstractConnectionPool` subclasses ready to
 be used.
@@ -58,7 +75,3 @@ be used.
 .. autoclass:: ThreadedConnectionPool
 
     .. note:: This pool class can be safely used in multi-threaded applications.
-
-.. autoclass:: CachingConnectionPool
-
-    .. note:: Expired connections are cleaned up on any call to putconn.

--- a/doc/src/pool.rst
+++ b/doc/src/pool.rst
@@ -58,3 +58,7 @@ be used.
 .. autoclass:: ThreadedConnectionPool
 
     .. note:: This pool class can be safely used in multi-threaded applications.
+
+.. autoclass:: CachingConnectionPool
+
+    .. note:: Expired connections are cleaned up on any call to putconn.

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -316,13 +316,13 @@ class CachingConnectionPool(AbstractConnectionPool):
                 for conn in self._used.values():
                     if id(conn) == obj_id:
                         break  #found it, so just move on. Don't expire the
-                    # connection till we are done with it.
-                    else:
-                        # This connection doesn't exist any more, so get rid
-                        # of the reference to the expiration.
-                        # Can't delete here because we'd be changing the item
-                        # we are itterating over.
-                        junk_expirations.append(obj_id)
+                                # connection till we are done with it.
+                else:
+                    # This connection doesn't exist any more, so get rid
+                    # of the reference to the expiration.
+                    # Can't delete here because we'd be changing the item
+                    # we are itterating over.
+                    junk_expirations.append(obj_id)
 
             # Delete connection from pool if expired
             if del_idx is not None:
@@ -330,10 +330,8 @@ class CachingConnectionPool(AbstractConnectionPool):
 
         # Remove any junk expirations
         for item in junk_expirations:
-            try:
-                del self._expirations[item]
-            except KeyError:
-                pass  #expiration doesn't exist??
+            # Should be safe enough, since it existed in the loop above
+            del self._expirations[item]
 
         # Make sure we still have at least minconn connections
         # Connections may be available or used

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -298,6 +298,7 @@ class CachingConnectionPool(AbstractConnectionPool):
 
     def _prune(self):
         """Remove any expired connections from the connection pool."""
+        from datetime import datetime, timedelta
         junk_expirations = []
         for obj_id, exp_time in self._expirations.items():
             # _expirations is an ordered dict, so results should be in chronological order

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -184,3 +184,163 @@ class ThreadedConnectionPool(AbstractConnectionPool):
             self._closeall()
         finally:
             self._lock.release()
+
+
+class CachingConnectionPool(AbstractConnectionPool):
+    """A connection pool that works with the threading module and caches connections"""
+
+    # A dictionary to hold connection ID's and when they should be removed from the pool
+    # Keys are id(connection) and vlaues are expiration time
+    # Storing the expiration time on the connection itself might be preferable, if possible.
+    from collections import OrderedDict
+    _expirations = OrderedDict()
+
+    def __init__(self, minconn, maxconn, lifetime = 3600, *args, **kwargs):
+        """Initialize the threading lock."""
+        import threading
+        from datetime import datetime, timedelta
+        AbstractConnectionPool.__init__(
+            self, minconn, maxconn, *args, **kwargs)
+        self._lock = threading.Lock()
+        self._lifetime = lifetime
+
+    def _connect(self, key=None):
+        """Create a new connection, assign it to 'key' if not None,
+        And assign an expiration time"""
+        conn = psycopg2.connect(*self._args, **self._kwargs)
+        if key is not None:
+            self._used[key] = conn
+            self._rused[id(conn)] = key
+        else:
+            self._pool.append(conn)
+
+        #Add expiration time
+        self._expirations[id(conn)] = datetime.now() + timedelta(seconds = self._lifetime)
+        return conn
+
+    # Override the _putconn function to put the connection back into the pool even if we are over minconn, and to run the _prune command.
+    def _putconn(self, conn, key=None, close=False):
+        """Put away a connection."""
+        if self.closed:
+            raise PoolError("connection pool is closed")
+        if key is None:
+            key = self._rused.get(id(conn))
+
+        if not key:
+            raise PoolError("trying to put unkeyed connection")
+
+        if len(self._pool) < self.maxconn and not close:
+            # Return the connection into a consistent state before putting
+            # it back into the pool
+            if not conn.closed:
+                status = conn.get_transaction_status()
+                if status == _ext.TRANSACTION_STATUS_UNKNOWN:
+                    # server connection lost
+                    conn.close()
+                    try:
+                        del self._expirations[id(conn)]
+                    except KeyError:
+                        pass
+                elif status != _ext.TRANSACTION_STATUS_IDLE:
+                    # connection in error or in transaction
+                    conn.rollback()
+                    self._pool.append(conn)
+                else:
+                    # regular idle connection
+                    self._pool.append(conn)
+            # If the connection is closed, we just discard it.
+            else:
+                try:
+                    del self._expirations[id(conn)]
+                except KeyError:
+                    pass
+        else:
+            conn.close()
+            #remove this connection from the expiration list
+            try:
+                del self._expirations[id(conn)]
+            except KeyError:
+                pass  #not in the expiration list for some reason, can't remove it.
+
+        # here we check for the presence of key because it can happen that a
+        # thread tries to put back a connection after a call to close
+        if not self.closed or key in self._used:
+            del self._used[key]
+            del self._rused[id(conn)]
+
+        # remove any expired connections from the pool
+        self._prune()
+
+
+    def getconn(self, key=None):
+        """Get a free connection and assign it to 'key' if not None."""
+        self._lock.acquire()
+        try:
+            return self._getconn(key)
+        finally:
+            self._lock.release()
+
+    def putconn(self, conn=None, key=None, close=False):
+        """Put away an unused connection."""
+        self._lock.acquire()
+        try:
+            self._putconn(conn, key, close)
+        finally:
+            self._lock.release()
+
+    def closeall(self):
+        """Close all connections (even the one currently in use.)"""
+        self._lock.acquire()
+        try:
+            self._closeall()
+        finally:
+            self._lock.release()
+
+    def _prune(self):
+        """Remove any expired connections from the connection pool."""
+        junk_expirations = []
+        for obj_id, exp_time in self._expirations.items():
+            # _expirations is an ordered dict, so results should be in chronological order
+            if exp_time > datetime.now():
+                break;
+
+            del_idx = None
+            #find index of connection in _pool. May not be there if connection is in use
+            for index, conn in enumerate(self._pool):
+                if id(conn) == obj_id:
+                    conn.close()
+                    junk_expirations.append(obj_id)
+                    del_idx = index
+                    break
+            else:
+                # See if this connection is used. If not, we need to remove
+                # the reference to it.
+                for conn in self._used.values():
+                    if id(conn) == obj_id:
+                        break  #found it, so just move on. Don't expire the
+                    # connection till we are done with it.
+                    else:
+                        # This connection doesn't exist any more, so get rid
+                        # of the reference to the expiration.
+                        # Can't delete here because we'd be changing the item
+                        # we are itterating over.
+                        junk_expirations.append(obj_id)
+
+            # Delete connection from pool if expired
+            if del_idx is not None:
+                del self._pool[del_idx]
+
+
+        # Remove any junk expirations
+        for item in junk_expirations:
+            try:
+                del self._expirations[item]
+            except KeyError:
+                pass  #expiration doesn't exist??
+
+        # Make sure we still have at least minconn connections
+        # Connections may be available or used
+        total_conns = len(self._pool) + len(self._used)
+        if  total_conns < self.minconn:
+            for i in range(self.minconn - total_conns):
+                self._connect()

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -189,24 +189,24 @@ class ThreadedConnectionPool(AbstractConnectionPool):
 class CachingConnectionPool(AbstractConnectionPool):
     """A connection pool that works with the threading module and caches connections"""
 
-    # A dictionary to hold connection ID's and when they should be removed from the pool
-    # Keys are id(connection) and vlaues are expiration time
-    # Storing the expiration time on the connection itself might be preferable, if possible.
-    from collections import OrderedDict
-    _expirations = OrderedDict()
-
     def __init__(self, minconn, maxconn, lifetime = 3600, *args, **kwargs):
         """Initialize the threading lock."""
         import threading
-        from datetime import datetime, timedelta
         AbstractConnectionPool.__init__(
             self, minconn, maxconn, *args, **kwargs)
         self._lock = threading.Lock()
         self._lifetime = lifetime
 
+        # A dictionary to hold connection ID's and when they should be removed from the pool
+        # Keys are id(connection) and vlaues are expiration time
+        # Storing the expiration time on the connection itself might be preferable, if possible.
+        from collections import OrderedDict
+        self._expirations = OrderedDict()
+
     def _connect(self, key=None):
         """Create a new connection, assign it to 'key' if not None,
         And assign an expiration time"""
+        from datetime import datetime, timedelta
         conn = psycopg2.connect(*self._args, **self._kwargs)
         if key is not None:
             self._used[key] = conn

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,6 +48,7 @@ from . import test_ipaddress
 from . import test_lobject
 from . import test_module
 from . import test_notify
+from . import test_pool
 from . import test_psycopg2_dbapi20
 from . import test_quote
 from . import test_replication
@@ -93,6 +94,7 @@ def test_suite():
     suite.addTest(test_lobject.test_suite())
     suite.addTest(test_module.test_suite())
     suite.addTest(test_notify.test_suite())
+    suite.addTest(test_pool.test_suite())
     suite.addTest(test_psycopg2_dbapi20.test_suite())
     suite.addTest(test_quote.test_suite())
     suite.addTest(test_replication.test_suite())

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+# test_pool.py - unit test for psycopg2 classes
+#
+# psycopg2 is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders give
+# permission to link this program with the OpenSSL library (or with
+# modified versions of OpenSSL that use the same license as OpenSSL),
+# and distribute linked combinations including the two.
+#
+# You must obey the GNU Lesser General Public License in all respects for
+# all of the code used other than OpenSSL.
+#
+# psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+
+from datetime import datetime, timedelta
+import psycopg2
+import psycopg2.pool as psycopg_pool
+from testutils import (unittest, ConnectingTestCase, skip_before_postgres,
+    skip_if_no_namedtuple, skip_if_no_getrefcount, slow, skip_if_no_superuser,
+    skip_if_windows)
+
+from testconfig import dsn, dbname
+
+class PoolTests(ConnectingTestCase):
+    #----------------------------------------------------------------------
+    def test_caching_pool_create_connection(self):
+        """Test that the _connect function creates and returns a connection"""
+        lifetime = 30
+        pool = psycopg_pool.CachingConnectionPool(0, 1, lifetime, dsn)
+        expected_expires = datetime.now() + timedelta(seconds = lifetime)
+        conn = pool._connect()
+
+        #Verify we have one entry in the expiration table
+        self.assertEqual(len(pool._expirations), 1)
+
+        # and that the connection is actually opened
+        self.assertFalse(conn.closed)
+
+        actual_expires = pool._expirations[id(conn)]
+
+        # there may be some slight variation between when we created the connection
+        # and our "expected" expiration.
+        # Should be negligable, however
+        self.assertAlmostEqual(expected_expires, actual_expires, delta = timedelta(seconds = 1))
+
+    def test_caching_pool_get_conn(self):
+        """Test the call to getconn. Should just return an open connection."""
+        pool = psycopg_pool.CachingConnectionPool(0, 1, 30, dsn)
+        conn = pool.getconn()
+
+        #make sure we got an open connection
+        self.assertFalse(conn.closed)
+
+        #Try again. We should get an error, since we only allowed one connection
+        self.assertRaises(psycopg2.pool.PoolError, pool.getconn)
+
+    def test_caching_pool_prune(self):
+        """Test the prune function to make sure it closes conenctions and removes them from the pool"""
+        pool = psycopg_pool.CachingConnectionPool(0, 1, 30, dsn)
+
+        # Get a connection that we use, so it can't be pruned.
+        sticky_conn = pool.getconn()
+        self.assertFalse(sticky_conn in pool._pool)
+        self.assertTrue(sticky_conn in pool._used.values())
+        self.assertFalse(sticky_conn.closed)
+        self.assertTrue(id(sticky_conn) in pool._expirations)
+
+        # create a second connection that is left in the pool, available to be pruned.
+        conn = pool._connect()
+        self.assertTrue(conn in pool._pool)
+        self.assertFalse(conn in pool._used.values())
+        self.assertFalse(conn.closed)
+        self.assertTrue(id(conn) in pool._expirations)
+
+        self.assertNotEqual(conn, sticky_conn)
+
+        #Make the connections expire a minute ago
+        old_expire = datetime.now() - timedelta(minutes = 1)
+
+        pool._expirations[id(conn)] = old_expire
+        pool._expirations[id(sticky_conn)] = old_expire
+
+        #prune connections
+        pool._prune()
+
+        #make sure the unused connection is gone and closed, but the used connection isn't
+        self.assertFalse(conn in pool._pool)
+        self.assertTrue(conn.closed)
+        self.assertFalse(id(conn) in pool._expirations)
+
+        self.assertFalse(sticky_conn.closed)
+        self.assertTrue(id(sticky_conn) in pool._expirations)
+
+    def test_caching_pool_putconn(self):
+        pool = psycopg_pool.CachingConnectionPool(0, 1, 30, dsn)
+        conn = pool.getconn()
+        self.assertFalse(conn in pool._pool)
+
+        pool.putconn(conn)
+        self.assertTrue(conn in pool._pool)
+
+        conn2 = pool.getconn()
+
+        #expire the connection
+        pool._expirations[id(conn2)] = datetime.now() - timedelta(minutes = 1)
+        pool.putconn(conn2)
+
+        #connection should be discarded
+        self.assertFalse(conn2 in pool._pool)
+        self.assertFalse(id(conn2) in pool._expirations)
+        self.assertTrue(conn2.closed)
+
+    def test_caching_pool_caching(self):
+        pool = psycopg_pool.CachingConnectionPool(0, 10, 30, dsn)
+
+        # Get a connection to use to check the number of connections
+        check_conn = pool.getconn()
+        check_conn.autocommit = True  # Being in a transaction hides the other connections.
+        # Get a cursor to run check queries with
+        check_cursor = check_conn.cursor()
+
+        SQL = "SELECT numbackends from pg_stat_database WHERE datname=%s"
+        check_cursor.execute(SQL, (dbname, ))
+
+        #not trying to test anything yet, so hopefully this always works :)
+        starting_conns = check_cursor.fetchone()[0]
+
+        #Get a couple more connections
+        conn2 = pool.getconn()
+        conn3 = pool.getconn()
+
+        self.assertEqual(len(pool._expirations), 3)
+
+        self.assertNotEqual(conn2, conn3)
+
+        # Verify that we have the expected number of connections to the DB server now
+        check_cursor.execute(SQL, (dbname, ))
+        total_cons = check_cursor.fetchone()[0]
+
+        self.assertEqual(total_cons, starting_conns + 2)
+
+        #Put the connections back in the pool and verify they don't close
+        pool.putconn(conn2)
+        pool.putconn(conn3)
+
+        check_cursor.execute(SQL, (dbname, ))
+        total_cons_after_put = check_cursor.fetchone()[0]
+
+        self.assertEqual(total_cons, total_cons_after_put)
+
+        # Get another connection and verify we don't create a new one
+        conn4 = pool.getconn()
+
+        # conn4 should be either conn2 or conn3 (we don't care which)
+        self.assertTrue(conn4 in (conn2, conn3))
+
+        check_cursor.execute(SQL, (dbname, ))
+        total_cons_after_get = check_cursor.fetchone()[0]
+
+        self.assertEqual(total_cons_after_get, total_cons)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -27,7 +27,7 @@ import psycopg2.extensions as _ext
 import psycopg2.pool
 
 from .testconfig import dsn, dbname
-from .testutils import ConnectingTestCase
+from .testutils import ConnectingTestCase, skip_before_postgres
 
 
 class PoolTests(ConnectingTestCase):
@@ -202,6 +202,7 @@ class PoolTests(ConnectingTestCase):
         self.assertFalse(conn in pool._pool)
         self.assertFalse(id(conn) in pool._return_times)
 
+    @skip_before_postgres(8, 2)
     def test_caching(self):
         pool = psycopg2.pool.SimpleConnectionPool(0, 10, dsn, idle_timeout=30)
 


### PR DESCRIPTION
This PR is a rebased and refactored version of #565.

When a connection is added (via `_connect()`) or returned (via `_putconn()`) to the pool, a timestamp is saved. When `_getconn()` pulls a connection, it compares the saved timestamp to the current time, and if the connection has been idle for longer than `idle_timeout`, then that connection is closed and discarded.

I've set the default value of `idle_timeout` to `0` in order to replicate the current behavior, however another value could be chosen if there is consensus on changing the default behavior.

My first commit fixes two bugs in the current pool implementation:

1. The `_getconn()` method doesn't check the status of a connection, so it can return a broken connection.
2. The `_putconn()` method doesn't reopen new connections if the total has dropped below `minconn`.