### PR TITLE
Add Python 3.8 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 # Travis CI configuration file for psycopg2
 
-dist: xenial
-sudo: required
 language: python
 
 matrix:
   include:
     - python: 2.7
+    - python: 3.8
     - python: 3.7
     - python: 3.6
     - python: 3.5
     - python: 3.4
-      dist: trusty
 
 install:
   - pip install -U pip setuptools wheel

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -35,7 +35,7 @@ The current `!psycopg2` implementation supports:
     NOTE: keep consistent with setup.py and the /features/ page.
 
 - Python version 2.7
-- Python 3 versions from 3.4 to 3.7
+- Python 3 versions from 3.4 to 3.8
 - PostgreSQL server versions from 7.4 to 11
 - PostgreSQL client library version from 9.1
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: C
 Programming Language :: SQL

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}
+envlist = py{27,34,35,36,37,38}
 
 [testenv]
 commands = make check


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.

- Added 'Programming Language :: Python :: 3.8' trove classifier.
- Added 'py38' to the tox test matrix.
- Added 'python: 3.8' to the Travis test matrix.
- Removed 'dist: xenial' from Travis configuration; it is now the
  default.
- Removed 'dist: trusty' from Travis configuration; it is not longer
  necessary.
- Removed 'sudo' from Travis configuration; it is deprecated.

https://docs.python.org/3.8/whatsnew/3.8.html