### PR TITLE
feat: Add AIX support

### DIFF
--- a/psycopg/aix_support.c
+++ b/psycopg/aix_support.c
@@ -1,0 +1,58 @@
+/* aix_support.c - emulate functions missing on AIX
+ *
+ * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ * Copyright (c) 2018, Joyent, Inc.
+ * Copyright (C) 2020 The Psycopg Team
+ *
+ * This file is part of psycopg.
+ *
+ * psycopg2 is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link this program with the OpenSSL library (or with
+ * modified versions of OpenSSL that use the same license as OpenSSL),
+ * and distribute linked combinations including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects for
+ * all of the code used other than OpenSSL.
+ *
+ * psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+
+#define PSYCOPG_MODULE
+#include "psycopg/psycopg.h"
+#include "psycopg/aix_support.h"
+
+#if defined(_AIX)
+/* timeradd is missing on AIX */
+#ifndef timeradd
+void
+timeradd(struct timeval *a, struct timeval *b, struct timeval *c)
+{
+    c->tv_sec = a->tv_sec + b->tv_sec;
+    c->tv_usec = a->tv_usec + b->tv_usec;
+    if (c->tv_usec >= 1000000) {
+        c->tv_usec -= 1000000;
+        c->tv_sec += 1;
+    }
+}
+
+/* timersub is missing on AIX */
+void
+timersub(struct timeval *a, struct timeval *b, struct timeval *c)
+{
+    c->tv_sec = a->tv_sec - b->tv_sec;
+    c->tv_usec = a->tv_usec - b->tv_usec;
+    if (c->tv_usec < 0) {
+        c->tv_usec += 1000000;
+        c->tv_sec -= 1;
+    }
+}
+#endif /* timeradd */
+#endif /* defined(_AIX)*/

--- a/psycopg/aix_support.h
+++ b/psycopg/aix_support.h
@@ -1,0 +1,48 @@
+/* aix_support.h - definitions for aix_support.c
+ *
+ * Copyright (C) 2017 My Karlsson <mk@acc.umu.se>
+ * Copyright (c) 2018-2019, Joyent, Inc.
+ * Copyright (C) 2020 The Psycopg Team
+ *
+ * This file is part of psycopg.
+ *
+ * psycopg2 is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link this program with the OpenSSL library (or with
+ * modified versions of OpenSSL that use the same license as OpenSSL),
+ * and distribute linked combinations including the two.
+ *
+ * You must obey the GNU Lesser General Public License in all respects for
+ * all of the code used other than OpenSSL.
+ *
+ * psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+#ifndef PSYCOPG_AIX_SUPPORT_H
+#define PSYCOPG_AIX_SUPPORT_H
+
+#include "psycopg/config.h"
+
+#if defined(__sun) && defined(__SVR4)
+#include <sys/time.h>
+
+#ifndef timeradd
+extern HIDDEN void timeradd(struct timeval *a, struct timeval *b, struct timeval *c);
+extern HIDDEN void timersub(struct timeval *a, struct timeval *b, struct timeval *c);
+#endif
+
+#ifndef timercmp
+#define timercmp(a, b, cmp)          \
+  (((a)->tv_sec == (b)->tv_sec) ?    \
+   ((a)->tv_usec cmp (b)->tv_usec) : \
+   ((a)->tv_sec  cmp (b)->tv_sec))
+#endif
+#endif
+
+#endif /* !defined(PSYCOPG_AIX_SUPPORT_H) */

--- a/psycopg/aix_support.h
+++ b/psycopg/aix_support.h
@@ -29,7 +29,7 @@
 
 #include "psycopg/config.h"
 
-#if defined(__sun) && defined(__SVR4)
+#ifdef _AIX
 #include <sys/time.h>
 
 #ifndef timeradd

--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -54,6 +54,8 @@
 #include "win32_support.h"
 #elif defined(__sun) && defined(__SVR4)
 #include "solaris_support.h"
+#elif defined(_AIX)
+#include "aix_support.h"
 #else
 #include <sys/time.h>
 #endif

--- a/setup.py
+++ b/setup.py
@@ -483,7 +483,7 @@ data_files = []
 sources = [
     'psycopgmodule.c',
     'green.c', 'pqpath.c', 'utils.c', 'bytes_format.c',
-    'libpq_support.c', 'win32_support.c', 'solaris_support.c',
+    'libpq_support.c', 'win32_support.c', 'solaris_support.c', 'aix_support.c',
 
     'connection_int.c', 'connection_type.c',
     'cursor_int.c', 'cursor_type.c', 'column_type.c',


### PR DESCRIPTION
AIX has the same issue as Solaris no .timeradd or .timersub

```
ld: 0711-317 ERROR: Undefined symbol: .timeradd

ld: 0711-317 ERROR: Undefined symbol: .timersub
```
This patch was derived from solaris_support.h and solaris_support.c

Resolves #105

