### PR TITLE
Add calling stored procedurs that have transaction control to list of…

### DIFF
--- a/doc/src/connection.rst
+++ b/doc/src/connection.rst
@@ -431,8 +431,8 @@ The ``connection`` class
         invoked to terminate the transaction.
 
         The autocommit mode is useful to execute commands requiring to be run
-        outside a transaction, such as :sql:`CREATE DATABASE` or
-        :sql:`VACUUM`.
+        outside a transaction, such as :sql:`CREATE DATABASE`,
+        :sql:`VACUUM`, or calling stored procedures with transaction control inside.
 
         The default is `!False` (manual commit) as per DBAPI specification.
 

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -743,8 +743,9 @@ methods.  The level can be set to one of the following constants:
 
     No transaction is started when commands are executed and no
     `~connection.commit()` or `~connection.rollback()` is required.
-    Some PostgreSQL command such as :sql:`CREATE DATABASE` or :sql:`VACUUM`
-    can't run into a transaction: to run such command use::
+    Some PostgreSQL commands such as :sql:`CREATE DATABASE`, :sql:`VACUUM`,
+    or calling stored procedures with transaction control inside
+    can't run inside a transaction: to run such command use::
 
         >>> conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
 

--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -757,7 +757,8 @@ will result in an implicit rollback.
 
 It is possible to set the connection in *autocommit* mode: this way all the
 commands executed will be immediately committed and no rollback is possible. A
-few commands (e.g. :sql:`CREATE DATABASE`, :sql:`VACUUM`...) require to be run
+few commands (e.g. :sql:`CREATE DATABASE`, :sql:`VACUUM`, calling stored
+procedures with transaction control inside...) require to be run
 outside any transaction: in order to be able to run these commands from
 Psycopg, the connection must be in autocommit mode: you can use the
 `~connection.autocommit` property.


### PR DESCRIPTION
Doc update - Include calling stored procedures that have transaction control inside to the list of SQL commands to be run with autocommit set to false.