### PR TITLE
Fix memory leak in conn_set_client_encoding

### DIFF
--- a/psycopg/connection_int.c
+++ b/psycopg/connection_int.c
@@ -1389,7 +1389,10 @@ conn_set_client_encoding(connectionObject *self, const char *pgenc)
 
     /* If the current encoding is equal to the requested one we don't
        issue any query to the backend */
-    if (strcmp(self->encoding, clean_enc) == 0) return 0;
+    if (strcmp(self->encoding, clean_enc) == 0) {
+        res = 0;
+        goto exit;
+    }
 
     Py_BEGIN_ALLOW_THREADS;
     pthread_mutex_lock(&self->lock);


### PR DESCRIPTION
If the specified encoding is the same as the current one,
the early exit did not release the clean_enc string allocated
by clear_encoding_name.