### PR TITLE
Handle failure in setup of ConnectionTwoPhaseTest

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -913,9 +913,11 @@ class ConnectionTwoPhaseTests(ConnectingTestCase):
             cur.execute("DROP TABLE test_tpc;")
         except psycopg2.ProgrammingError:
             cnn.rollback()
-        cur.execute("CREATE TABLE test_tpc (data text);")
-        cnn.commit()
-        cnn.close()
+        try:
+            cur.execute("CREATE TABLE test_tpc (data text);")
+            cnn.commit()
+        finally:
+            cnn.close()
 
     def count_xacts(self):
         """Return the number of prepared xacts currently in the test db."""


### PR DESCRIPTION
Previously, this test had a bug, because if the CREATE TABLE statement
failed, the setup would fail without committing or rolling back the
active transaction.

This is needed because `tearDown` is not called if there was an error
during `setUp` ([as specified by the `unittest` docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.tearDown)).