### PR TITLE
DictCursor docs improvement

### DIFF
--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -41,8 +41,8 @@ If you want to use a `!connection` subclass you can pass it as the
 Dictionary-like cursor
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The dict cursors allow to access to the retrieved records using an interface
-similar to the Python dictionaries instead of the tuples.
+The dict cursors allow to access to the attributes of retrieved records
+using an interface similar to the Python dictionaries instead of the tuples.
 
     >>> dict_cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
     >>> dict_cur.execute("INSERT INTO test (num, data) VALUES(%s, %s)",

--- a/lib/extras.py
+++ b/lib/extras.py
@@ -130,7 +130,10 @@ class DictConnection(_connection):
 
 
 class DictCursor(DictCursorBase):
-    """A cursor that keeps a list of column name -> index mappings."""
+    """A cursor that keeps a list of column name -> index mappings__.
+
+    .. __: https://docs.python.org/glossary.html#term-mapping
+    """
 
     def __init__(self, *args, **kwargs):
         kwargs['row_factory'] = DictRow


### PR DESCRIPTION
Just to remind that the object received is a mapping in python sense, so it will work with double-asterisk unpacking and other fancy things. I deliberately don't promise it'll be an OrderedDict forever, as we may want to change it one day.