### PR TITLE
Handle failure in setup of IsolationLevelsTestCase

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -567,9 +567,11 @@ class IsolationLevelsTestCase(ConnectingTestCase):
             cur.execute("drop table isolevel;")
         except psycopg2.ProgrammingError:
             conn.rollback()
-        cur.execute("create table isolevel (id integer);")
-        conn.commit()
-        conn.close()
+        try:
+            cur.execute("create table isolevel (id integer);")
+            conn.commit()
+        finally:
+            conn.close()
 
     def test_isolation_level(self):
         conn = self.connect()


### PR DESCRIPTION
If the CREATE TABLE statement fails, the setup would fail
without committing or rolling back the active transaction, so the
transaction would hold onto its resources indefinitely.

Normally, the transaction would be closed when the connection is closed
in the `tearDown` function. However, `tearDown` is not called if there
was an error during `setUp` ([as specified by the `unittest` docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.tearDown)), so
we need to handle this case specially.