### PR TITLE
Classify SqlState Connection Exceptions as operational errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,15 @@
 Current release
 ---------------
 
+What's new in psycopg 2.9.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Reclassified SQLSTATE connection exceptions (08XXX) as
+  `~psycopg2.errors.OperationalError`, conforming better to
+  PEP 249.  This error is a subclass of previously used
+  `~psycopg2.errors.DatabaseError`.
+
+
 What's new in psycopg 2.8.6
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/psycopg/error_type.c
+++ b/psycopg/error_type.c
@@ -65,6 +65,8 @@ base_exception_from_sqlstate(const char *sqlstate)
     switch (sqlstate[0]) {
     case '0':
         switch (sqlstate[1]) {
+        case '8': /* Class 08 - Connection Exception */
+            return OperationalError;
         case 'A': /* Class 0A - Feature Not Supported */
             return NotSupportedError;
         }

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -62,6 +62,13 @@ class ErrorsTests(ConnectingTestCase):
         with self.assertRaises(KeyError):
             errors.lookup('XXXXX')
 
+    def test_connection_exceptions_backwards_compatibility(self):
+        err = errors.lookup('08000')
+        # connection exceptions are classified as operational errors
+        self.assert_(issubclass(err, errors.OperationalError))
+        # previously these errors were classified only as DatabaseError
+        self.assert_(issubclass(err, errors.DatabaseError))
+
     def test_has_base_exceptions(self):
         excs = []
         for n in dir(psycopg2):


### PR DESCRIPTION
tl;dr: conform with [PEP 249](https://www.python.org/dev/peps/pep-0249/#operationalerror`) better, so that libraries can treat disconnect errors caused by PgBouncer as transient.

DatabaseError is too broad and is considered **not** transient failure by libraries, which causes failures where an operation could simply be re-tried, like [relstorage:drivers.py#L157](https://github.com/zodb/relstorage/blob/9568c6b1447275fc8983ee025b28181218ae456b/src/relstorage/adapters/drivers.py#L157) or [pjpersist:datamanager.py#L100](https://github.com/Shoobx/pjpersist/blob/1c4ba9df7c71b621f87c25e0646352b3b74be5df/src/pjpersist/datamanager.py#L100)

A real world example: conntect to PgBouncer instead of Postgres directly.  Now, if the Postgres server is disrupted, you get a ProtocolViolation (SqlState 08P01) sent by PgBouncer: [pgbouncer:src/server.c#L481](https://github.com/pgbouncer/pgbouncer/blob/834917d41e19dee5d14f726bcebd02ee082fa3a9/src/server.c#L481) which leads to [pgbouncer:/src/proto.c#L128](https://github.com/pgbouncer/pgbouncer/blob/834917d41e19dee5d14f726bcebd02ee082fa3a9/src/proto.c#L128).

```
Traceback (most recent call last):
  File ".../ve3.7/lib/python3.7/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  <...>
  File ".../src/app/taskcontext.py", line 39, in celery_request
    conn = db.open()
  File ".../ve3.7/lib/python3.7/site-packages/ZODB/DB.py", line 793, in open
    result.open(transaction_manager)
  File ".../ve3.7/lib/python3.7/site-packages/ZODB/Connection.py", line 921, in open
    self.newTransaction(None, False)
  File ".../ve3.7/lib/python3.7/site-packages/ZODB/Connection.py", line 737, in newTransaction
    invalidated = self._storage.poll_invalidations()
  File ".../ve3.7/lib/python3.7/site-packages/relstorage/storage.py", line 1421, in poll_invalidations
    changes, new_polled_tid = self._restart_load_and_poll()
  File ".../ve3.7/lib/python3.7/site-packages/relstorage/storage.py", line 1395, in _restart_load_and_poll
    self._adapter.poller.poll_invalidations, prev, ignore_tid)
  File ".../ve3.7/lib/python3.7/site-packages/relstorage/storage.py", line 365, in _restart_load_and_call
    return f(self._load_conn, self._load_cursor, *args, **kw)
  File ".../ve3.7/lib/python3.7/site-packages/relstorage/adapters/poller.py", line 95, in poll_invalidations
    cursor.execute(self.poll_query)
psycopg2.errors.ProtocolViolation: server conn crashed?
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```


PEP 249 states that unexpected disconnects and similar failures not under programmers control should be considered OperationalFailure, so higher level library developers tend to treat that exception transient.

OperationalError is inherited from DatabaseError, so this PR is mostly backwards-compatible.
