### PR TITLE
Ignore decode errors in conn_decode()

### DIFF
--- a/psycopg/connection_int.c
+++ b/psycopg/connection_int.c
@@ -126,15 +126,17 @@ conn_decode(connectionObject *self, const char *str, Py_ssize_t len)
 
     if (self) {
         if (self->cdecoder) {
-            return self->cdecoder(str, len, NULL);
+            return self->cdecoder(str, len, "ignore");
         }
         else if (self->pydecoder) {
             PyObject *b = NULL;
             PyObject *t = NULL;
             PyObject *rv = NULL;
+            static PyObject *errors = NULL;
 
             if (!(b = Bytes_FromStringAndSize(str, len))) { goto error; }
-            if (!(t = PyObject_CallFunctionObjArgs(self->pydecoder, b, NULL))) {
+            if (!(errors = PyUnicode_FromString("ignore"))) { goto error; }
+            if (!(t = PyObject_CallFunctionObjArgs(self->pydecoder, b, errors, NULL))) {
                 goto error;
             }
             if (!(rv = PyTuple_GetItem(t, 0))) { goto error; }


### PR DESCRIPTION
The previous error handling mode (the default "strict" mode) is problematic when trying to access data with different encoding, for instance from the `pg_stat_activity` view as shown in the following issue in pg_activity: https://github.com/dalibo/pg_activity/issues/149#issuecomment-718476674.

With this change, decoding errors are now ignored, so the behavior is similar to psql.