### PR TITLE
Add support for PostgreSQL 13 (final)

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -133,7 +133,7 @@ The current `!psycopg2` implementation supports:
 
 - Python version 2.7
 - Python 3 versions from 3.4 to 3.8
-- PostgreSQL server versions from 7.4 to 12
+- PostgreSQL server versions from 7.4 to 13
 - PostgreSQL client library version from 9.1
 
 

--- a/scripts/travis_prepare.sh
+++ b/scripts/travis_prepare.sh
@@ -125,6 +125,7 @@ if (( "$TEST_PRESENT" )); then
     # Postgres versions supported by ARM64
         create 10
     else
+        create 13
         create 12
         create 11
         create 10
@@ -150,5 +151,6 @@ fi
 
 # Postgres built from master
 if (( "$TEST_FUTURE" )); then
-    create 13 13-master
+    # create 14 14-master
+    true
 fi

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -56,6 +56,7 @@ if (( "$TEST_PRESENT" )); then
         run_test 10
     else
     # Postgres versions supported by Travis CI
+        run_test 13
         run_test 12
         run_test 11
         run_test 10
@@ -81,5 +82,6 @@ fi
 
 # Postgres built from master
 if (( "$TEST_FUTURE" )); then
-    run_test 13
+    # create 14 14-master
+    true
 fi


### PR DESCRIPTION
Since 2020-09-24 PostgreSQL is no longer the future 😃 

I added PostgreSQL 13 to run as part of the build pipeline and updated the docs to reflect support for version 13 as well.

Feel free to tell me if anything is missing, thanks!