### PR TITLE
Removed Windows builds for Python 2.7/3.4 and link against libpq 13.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,13 +21,9 @@ environment:
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "36", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "35", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "35", PY_ARCH: "64"}
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "32"}
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "64"}
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "27", PY_ARCH: "32"}
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "27", PY_ARCH: "64"}
 
     OPENSSL_VERSION: "1_1_1h"
-    POSTGRES_VERSION: "11_4"
+    POSTGRES_VERSION: "13_0"
 
     PSYCOPG2_TESTDB: psycopg2_test
     PSYCOPG2_TESTDB_USER: postgres

--- a/scripts/appveyor.cache_rebuild
+++ b/scripts/appveyor.cache_rebuild
@@ -12,7 +12,7 @@ OpenSSL
         Version: 1.1.1h
 
 PostgreSQL
-        Version: 11.4
+        Version: 13.0
 
 
 NOTE: to zap the cache manually you can also use:

--- a/scripts/appveyor.py
+++ b/scripts/appveyor.py
@@ -250,20 +250,6 @@ def build_libpq():
     pgbuild = opt.build_dir / f"postgres-REL_{ver}"
     os.chdir(pgbuild)
 
-    # Patch for OpenSSL 1.1 configuration. See:
-    # https://www.postgresql-archive.org/Compile-psql-9-6-with-SSL-Version-1-1-0-td6054118.html
-    assert Path("src/include/pg_config.h.win32").exists()
-    with open("src/include/pg_config.h.win32", 'a') as f:
-        print(
-            """
-#define HAVE_ASN1_STRING_GET0_DATA 1
-#define HAVE_BIO_GET_DATA 1
-#define HAVE_BIO_METH_NEW 1
-#define HAVE_OPENSSL_INIT_SSL 1
-""",
-            file=f,
-        )
-
     # Setup build config file (config.pl)
     os.chdir("src/tools/msvc")
     with open("config.pl", 'w') as f:

--- a/scripts/appveyor.py
+++ b/scripts/appveyor.py
@@ -326,7 +326,7 @@ def build_psycopg():
     add_pg_config_path()
     run_python(
         ["setup.py", "build_ext", "--have-ssl"]
-        + ["-l", "libpgcommon", "-l", "libpgport"]
+        + ["-l", "libpgcommon libpgport"]
         + ["-L", opt.ssl_build_dir / 'lib']
         + ['-I', opt.ssl_build_dir / 'include']
     )

--- a/scripts/appveyor.py
+++ b/scripts/appveyor.py
@@ -53,6 +53,7 @@ def setup_build_env():
         str(opt.py_dir / 'Scripts'),
         r'C:\Strawberry\Perl\bin',
         r'C:\Program Files\Git\mingw64\bin',
+        str(opt.ssl_build_dir / 'bin'),
         os.environ['PATH'],
     ]
     setenv('PATH', os.pathsep.join(path))
@@ -212,7 +213,7 @@ def build_openssl():
         + ['no-shared', 'no-zlib', f'--prefix={top}', f'--openssldir={top}']
     )
 
-    run_command("nmake build_libs install_dev".split())
+    run_command("nmake build_libs install_sw".split())
 
     assert (top / 'lib' / 'libssl.lib').exists()
 


### PR DESCRIPTION
Removed support for building Python 2.7 and 3.4 binaries in AppVeyor and changed PostgreSQL libpq library linkage from version 11.x to 13.0.  Version of Postgres > 11 do not have build support for Visual Studio versions before 2013 requiring dropping support of versions of Python that are built against older version (Python 2.7 uses 2008 and Python 3.4 uses 2010).
