### PR TITLE
Skip test_9_6_diagnostics test for CRDB

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -280,6 +280,7 @@ class ExceptionsTestCase(ConnectingTestCase):
         self.assertEqual(e.diag.constraint_name, "chk_eq1")
         self.assertEqual(e.diag.datatype_name, None)
 
+    @skip_if_crdb("diagnostic")
     @skip_before_postgres(9, 6)
     def test_9_6_diagnostics(self):
         cur = self.conn.cursor()


### PR DESCRIPTION
Previously, the CRDB's pg server version was 9.5, which meant this test
wasn't run as it is skipped for versions 9.6 and before. Now that the
server version of CRDB is 13, this check no longer applies.

This patch explicitly skips test_9_6_diagnostics for CRDB. The reason
for this is the same as test_9_3_diagnostics, which is currently
skipped for CRDB.