### PR TITLE
ci: first stab at running CI as github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Build documentation
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  docs:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: install requirements
+      run: pip install --upgrade pip setuptools wheel
+    - name: run tests
+      run: TRAVIS_PYTHON_VERSION=3.6 ./scripts/travis_update_docs.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - 2.7
+        - 3.6
+        - 3.7
+        - 3.8
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: install requirements
+      run: pip install --upgrade pip setuptools wheel
+    - name: install local project
+      run: pip install .
+    - name: cleanup local egg info
+      run: rm -rf psycopg2.egg-info
+    - name: setup test databases
+      run: sudo ./scripts/travis_prepare.sh
+    - name: run tests
+      run: ./scripts/travis_test.sh


### PR DESCRIPTION
There are some differences between this and travis configuration:
- Python 2.7 is treated as the others, can't understand travis config aim
- There's no arm64 workers in github actions
- Cannot test docs building because you have to set the token
- Notifications options documented here https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#github-actions-notification-options

Stuff can be simplified a bit more later when it's not needed to keep travis running.

Props to @AdamChainz for sharing its setup.