### PR TITLE
Add warning about send_feedback and cursor choice

### DIFF
--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -445,7 +445,9 @@ The individual messages in the replication stream are represented by
         If the *reply* or *force* parameters are not set, this method will
         just update internal structures without sending the feedback message
         to the server. The library sends feedback message automatically
-        when *status_interval* timeout is reached.
+        when *status_interval* timeout is reached. For this to work, you must
+        call `send_feedback()` on the same Cursor that you called `start_replication()`
+        on (the one in `message.cursor`) or your feedback will be lost.
 
         .. versionchanged:: 2.8.3
             added the *force* parameter.


### PR DESCRIPTION
It's not obvious that you cannot call `send_feedback()` on a temporary Cursor, and took me a long time to debug why it wasn't working. Improve the docs by making it clearer.