### PR TITLE
Fixes #1252 - Increment refcount on provided parameters.

### DIFF
--- a/psycopg/column_type.c
+++ b/psycopg/column_type.c
@@ -108,6 +108,16 @@ column_init(columnObject *self, PyObject *args, PyObject *kwargs)
         return -1;
     }
 
+    Py_XINCREF(self->name);
+    Py_XINCREF(self->type_code);
+    Py_XINCREF(self->display_size);
+    Py_XINCREF(self->internal_size);
+    Py_XINCREF(self->precision);
+    Py_XINCREF(self->scale);
+    Py_XINCREF(self->null_ok);
+    Py_XINCREF(self->table_oid);
+    Py_XINCREF(self->table_column);
+
     return 0;
 }
 


### PR DESCRIPTION
When parsing an object (`O`) with `PyArg_ParseTuple` and friends, the
provided object is set in the appropiate field, but the refcount is not
incremented. Reference:
https://docs.python.org/3/c-api/arg.html#other-objects.

Use `Py_XINCREF` to increment the refcount on any objects that may have
been passed into this function. `Py_XINCREF` performs a NULL check
internally and only increments the refcounter on non-NULL objects.