### PR TITLE
Don't abort if sqlstate_errors already initialized

### DIFF
--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -608,6 +608,10 @@ encodings_init(PyObject *module)
     int rv = -1;
 
     Dprintf("psycopgmodule: initializing encodings table");
+    if (psycoEncodings) {
+        Dprintf("encodings_init(): already called");
+        return 0;
+    }
 
     if (!(psycoEncodings = PyDict_New())) { goto exit; }
     Py_INCREF(psycoEncodings);

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -770,9 +770,8 @@ sqlstate_errors_init(PyObject *module)
     Dprintf("psycopgmodule: initializing sqlstate exceptions");
 
     if (sqlstate_errors) {
-        PyErr_SetString(PyExc_SystemError,
-            "sqlstate_errors_init(): already called");
-        goto exit;
+		Dprintf("sqlstate_errors_init(): already called");
+        return 0;
     }
     if (!(errmodule = PyImport_ImportModule("psycopg2.errors"))) {
         /* don't inject the exceptions into the errors module */


### PR DESCRIPTION
When using psycopg2 through Apache mod_wsgi, on various setups (in particular on Windows Server) I've hit the exception

    SystemError: initialization of _psycopg raised unreported exception

Investigation shows the exception is thrown here [1]. Given that `sqlstate_errors` is a static global [2], the following note (see [3]) rang a bell:

    A third issue is that the C extension module may cache references to Python objects in static variables but not actually increment the reference count on the objects in respect of its own reference to the objects. When the last Python sub interpreter to hold a reference to that Python object is destroyed, the object itself would be destroyed but the static variable left with a dangling pointer. If a new Python sub interpreter is then created and the C extension module attempts to use that cached Python object, accessing it or using it will likely cause the process to crash at some point.

    A few examples of Python modules which exhibit one or more of these problems are psycopg2, PyProtocols and lxml. In the case of !PyProtocols, because this module is used by TurboGears and sometimes used indirectly by Pylons applications, it means that the interpreter reloading mechanism can not be used with either of these packages. The reason for the problems with !PyProtocols appear to stem from its use of Pyrex generated code. The lxml package similarly uses Pyrex and is thus afflicted.

Interestingly, it explicitly mentions both static variables and psycopg2, so I wonder whether this is actually a known issue?

In any event, as far as I can tell (without indepth knowledge of the psycopg2 code), it looks like `sqlstate_errors` just needs to be populated once with the error lookup table, and then can be safely reused, so rather than aborting when it is already populated, I suppose one can just omit its initialization and proceed normally. This proposed fix solved the errors for me.

As a side note, I wonder whether there is something wrong with the exception reporting? The code called `PyErr_SetString` to report `sqlstate_errors_init(): already called`, but that error string doesn't end up getting shown to the user, rather `initialization of _psycopg raised unreported exception` is shown to the user as noted above.

As a second note, the same problem theoretically applies to `psycoEncodings`, which however is simply always reinitialized regardless of the previous state, which would be a memory leak. If the above suggestions holds for `sqlstate_errors`, it should be safe to also just omit re-initializing `psycoEncodings` if it is already initialized.

[1] https://github.com/psycopg/psycopg2/blob/442f300e9152aa6c57a50fc797dc0828b5fb979b/psycopg/psycopgmodule.c#L775
[2] https://github.com/psycopg/psycopg2/blob/442f300e9152aa6c57a50fc797dc0828b5fb979b/psycopg/psycopgmodule.c#L66
[3] https://modwsgi.readthedocs.io/en/master/user-guides/application-issues.html