### PR TITLE
Add s back to placeholder string

### DIFF
--- a/lib/sql.py
+++ b/lib/sql.py
@@ -442,7 +442,7 @@ class Placeholder(Composable):
 
     def as_string(self, context):
         if self._wrapped is not None:
-            return f"%({self._wrapped})"
+            return f"%({self._wrapped})s"
         else:
             return "%s"
 


### PR DESCRIPTION
execute and mogrify error due to an s not being included at the end of named placeholder strings.
in prior versions sql.Placeholder included an `s` at the end of named placeholder strings. it no longer does this. 
I am making this pr under the assumption that this was done in error.