### PR TITLE
feat: Cross-compile macos arm64 wheels 

### DIFF
--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -1,0 +1,39 @@
+---
+name: Build packages
+on:
+  - pull_request
+
+
+jobs:
+  # This only uploads the arm64 wheels for Apple M1 Silicon usage
+  build-macos-arm64:
+    runs-on: macos-11.0
+    name: "build-macos (3.8-3.10, arm64)"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start postgresql service
+        # This skips updating brew when installing a package
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          brew services start postgresql
+
+      # This builds all possible Python versions (currently, 3.8 to 3.10)
+      - uses: pypa/cibuildwheel@v2.1.1
+        # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
+        env:
+          CIBW_ARCHS: arm64
+          # XXX: temp: faster
+          CIBW_BUILD: cp39-macosx_arm64
+          CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+          # This allows substitution within setup.py
+          PACKAGE_NAME: psycopg2-binary
+
+      - run: |
+          ls -l
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages_macos_arm64
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -1,5 +1,5 @@
 ---
-name: Build packages
+name: Build packages (M1)
 on:
   - push
 

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -19,14 +19,12 @@ jobs:
           brew services start postgresql
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
-      - uses: pypa/cibuildwheel@v2.1.1
+      - uses: armenzg/cibuildwheel
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64
           # XXX: temp: faster
           CIBW_BUILD: cp39-macosx_arm64
-          CIBW_BUILD_VERBOSITY: 3
-          CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
           # It silences a warning since we can't test on Apple Silicon runners
           CIBW_TEST_SKIP: "*-macosx_arm64"
           # This allows substitution within setup.py

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -19,7 +19,7 @@ jobs:
           brew services start postgresql
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
-      - uses: armenzg/cibuildwheel
+      - uses: armenzg/cibuildwheel@main
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -39,7 +39,7 @@ jobs:
           name: packages_macos_arm64
           path: ./wheelhouse/*.whl
 
-build-macos:
+  build-macos:
     runs-on: macos-10.15
     strategy:
       fail-fast: false

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -1,7 +1,7 @@
 ---
 name: Build packages
 on:
-  - pull_request
+  - push
 
 
 jobs:
@@ -26,6 +26,8 @@ jobs:
           # XXX: temp: faster
           CIBW_BUILD: cp39-macosx_arm64
           CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+          # It silences a warning since we can't test on Apple Silicon runners
+          CIBW_TEST_SKIP: "*-macosx_arm64"
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
 

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -38,3 +38,38 @@ jobs:
         with:
           name: packages_macos_arm64
           path: ./wheelhouse/*.whl
+
+build-macos:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8']
+
+    steps:
+      - name: Checkout repos
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build packages
+        run: ./scripts/build/build_macos.sh
+        env:
+          PACKAGE_NAME: psycopg2-binary
+          PSYCOPG2_TESTDB: postgres
+          PSYCOPG2_TEST_FAST: 1
+      
+      - run: |
+          ls -l
+          ls -l wheels
+          ls -l dist
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages_macos
+          path: |
+            dist/*/*${{ matrix.platform }}.whl

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -61,6 +61,8 @@ jobs:
           PACKAGE_NAME: psycopg2-binary
           PSYCOPG2_TESTDB: postgres
           PSYCOPG2_TEST_FAST: 1
+          ARCHFLAGS: "-arch arm64"
+          _PYTHON_HOST_PLATFORM: "macosx-11.0-arm64"
       
       - run: |
           ls -l

--- a/.github/workflows/m1.yml
+++ b/.github/workflows/m1.yml
@@ -25,6 +25,7 @@ jobs:
           CIBW_ARCHS: arm64
           # XXX: temp: faster
           CIBW_BUILD: cp39-macosx_arm64
+          CIBW_BUILD_VERBOSITY: 3
           CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
           # It silences a warning since we can't test on Apple Silicon runners
           CIBW_TEST_SKIP: "*-macosx_arm64"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,8 +2,6 @@
 name: Build packages
 on:
   - workflow_dispatch
-  # XXX: Temp change while working on PR; remove with prettier changes
-  - pull_request
 
 jobs:
   build-sdist:
@@ -52,15 +50,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+ 
   build-manylinux:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { tag: manylinux2014, arch: x86_64 }
-          - { tag: manylinux2014, arch: i686 }
-          - { tag: manylinux_2_24, arch: aarch64 }
-          - { tag: manylinux_2_24, arch: ppc64le }
+          - {tag: manylinux2014, arch: x86_64}
+          - {tag: manylinux2014, arch: i686}
+          - {tag: manylinux_2_24, arch: aarch64}
+          - {tag: manylinux_2_24, arch: ppc64le}
 
     runs-on: ubuntu-20.04
     steps:
@@ -112,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
       - name: Checkout repos

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -156,15 +156,11 @@ jobs:
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64
-          # This changes the default in order to place the wheel in "repaired_wheels"
-          # The -w argument requires an absolute path
-          # CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}"
+          CIBW_BUILD: cp39-macosx_arm64
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
 
       - run: |
-          ls -l
-          ls -l dist
           ls -l wheelhouse
 
       - name: Upload artifacts

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -158,7 +158,10 @@ jobs:
         env:
           CIBW_ARCHS: arm64
           # This changes the default in order to place the wheel in "repaired_wheels"
-          CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w repaired_wheels {wheel}
+          # The -w argument requires an absolute path
+          CIBW_REPAIR_WHEEL_COMMAND: |
+            delocate-listdeps {wheel} &&
+            delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,7 +3,6 @@ name: Build packages
 on:
   - workflow_dispatch
 
-
 jobs:
   build-sdist:
     strategy:
@@ -51,16 +50,15 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-
   build-manylinux:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {tag: manylinux2014, arch: x86_64}
-          - {tag: manylinux2014, arch: i686}
-          - {tag: manylinux_2_24, arch: aarch64}
-          - {tag: manylinux_2_24, arch: ppc64le}
+          - { tag: manylinux2014, arch: x86_64 }
+          - { tag: manylinux2014, arch: i686 }
+          - { tag: manylinux_2_24, arch: aarch64 }
+          - { tag: manylinux_2_24, arch: ppc64le }
 
     runs-on: ubuntu-20.04
     steps:
@@ -107,13 +105,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-
   build-macos:
     runs-on: macos-10.15
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
       - name: Checkout repos
@@ -137,3 +134,27 @@ jobs:
           name: packages_macos
           path: |
             dist/*/*${{ matrix.platform }}.whl
+
+  # This only uploads the arm64 wheels for Apple M1 silicon usage
+  build-macos-arm64:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+    name: "build-macos (3.8-3.10 - arm64)"
+    steps:
+      - uses: actions/checkout@v2
+      # This builds all possible Python versions (currently, 3.8 to 3.10)
+      - uses: pypa/cibuildwheel@v2.1.1
+        with:
+          output-dir: dist
+        # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
+        env:
+          CIBW_ARCHS_MACOS: arm64
+          # Skip testing the arm64 builds
+          CIBW_TEST_SKIP: "*:arm64"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages_macos
+          path: |
+            dist/*/*macosx_11_0_arm64.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,6 +3,7 @@ name: Build packages
 on:
   - workflow_dispatch
 
+
 jobs:
   build-sdist:
     strategy:
@@ -50,7 +51,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
- 
+
   build-manylinux:
     strategy:
       fail-fast: false
@@ -105,6 +106,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
 
   build-macos:
     runs-on: macos-10.15

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -140,32 +140,37 @@ jobs:
 
   # This only uploads the arm64 wheels for Apple M1 Silicon usage
   build-macos-arm64:
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-11.0
     strategy:
       fail-fast: false
-      matrix:
-        os: [macos-10.15, macos-11.0]
-    name: "build-${{ matrix.os }} - arm64"
+    name: "build-macos-11 - arm64"
     steps:
       - uses: actions/checkout@v2
       - name: Install pre-requisites
+        # This skips updating brew when installing a package
+        env: HOMEBREW_NO_AUTO_UPDATE=1 
         run: |
           brew install postgresql@13
           brew services start postgresql
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
       - uses: pypa/cibuildwheel@v2.1.1
-        with:
-          output-dir: dist
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64
+          # This changes the default in order to place the wheel in "repaired_wheels"
+          CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w repaired_wheels {wheel}
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
+      
+      - run: |
+          ls -l
+          ls -l dist
+          ls -l repaired_wheels
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: packages_${{ matrix.os }}_arm64
+          name: packages_macos_arm64
           path: |
-            dist/*macosx_11_0_arm64.whl
+            repaired_wheels/*.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -138,23 +138,20 @@ jobs:
           path: |
             dist/*/*${{ matrix.platform }}.whl
 
-  # This only uploads the arm64 wheels for Apple M1 silicon usage
+  # This only uploads the arm64 wheels for Apple M1 Silicon usage
   build-macos-arm64:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-10.15, macos-11.0]
-    name: "build-${{ matrix.os }} - arm64)"
+    name: "build-${{ matrix.os }} - arm64"
     steps:
       - uses: actions/checkout@v2
       - name: Install pre-requisites
         run: |
-          # brew install gnu-sed postgresql@13
           brew install postgresql@13
           brew services start postgresql
-          # gsed -i "s/^setup(name=\"psycopg2\"/setup(name=\"psycopg2-binary\"/" setup.py
-          # git diff
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
       - uses: pypa/cibuildwheel@v2.1.1
@@ -163,17 +160,8 @@ jobs:
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64
+          # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
-
-      - name: Some tests
-        run: |
-          git diff
-          ls -l dist
-          pip install psycopg2-binary --no-index -f dist/
-          python -c "import psycopg2; print(psycopg2.__version__)"
-          python -c "import psycopg2; print(psycopg2.__libpq_version__)"
-          python -c "import psycopg2; print(psycopg2.extensions.libpq_version())"
-          python -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -157,4 +157,4 @@ jobs:
         with:
           name: packages_macos
           path: |
-            dist/*/*macosx_11_0_arm64.whl
+            dist/*macosx_11_0_arm64.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,6 +2,8 @@
 name: Build packages
 on:
   - workflow_dispatch
+  # XXX: Temp change while working on PR; remove with prettier changes
+  - pull_request
 
 jobs:
   build-sdist:
@@ -137,24 +139,44 @@ jobs:
 
   # This only uploads the arm64 wheels for Apple M1 silicon usage
   build-macos-arm64:
-    runs-on: macos-10.15
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-    name: "build-macos (3.8-3.10 - arm64)"
+      matrix:
+        os: [macos-10.15, macos-11.0]
+    name: "build-${{ matrix.os }} - arm64)"
     steps:
       - uses: actions/checkout@v2
+      - name: Install pre-requisites
+        run: |
+          # brew install gnu-sed postgresql@13
+          brew install postgresql@13
+          brew services start postgresql
+          # gsed -i "s/^setup(name=\"psycopg2\"/setup(name=\"psycopg2-binary\"/" setup.py
+          # git diff
+
       # This builds all possible Python versions (currently, 3.8 to 3.10)
       - uses: pypa/cibuildwheel@v2.1.1
         with:
           output-dir: dist
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
-          CIBW_ARCHS_MACOS: arm64
-          # Skip testing the arm64 builds
-          CIBW_TEST_SKIP: "*:arm64"
+          CIBW_ARCHS: arm64
+          PACKAGE_NAME: psycopg2-binary
+
+      - name: Some tests
+        run: |
+          git diff
+          ls -l dist
+          pip install psycopg2-binary --no-index -f dist/
+          python -c "import psycopg2; print(psycopg2.__version__)"
+          python -c "import psycopg2; print(psycopg2.__libpq_version__)"
+          python -c "import psycopg2; print(psycopg2.extensions.libpq_version())"
+          python -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: packages_macos_arm64
+          name: packages_${{ matrix.os }}_arm64
           path: |
             dist/*macosx_11_0_arm64.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -156,12 +156,8 @@ jobs:
         # Read about options here https://cibuildwheel.readthedocs.io/en/stable/options
         env:
           CIBW_ARCHS: arm64
-          CIBW_BUILD: cp39-macosx_arm64
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
-
-      - run: |
-          ls -l wheelhouse
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -141,14 +141,13 @@ jobs:
   # This only uploads the arm64 wheels for Apple M1 Silicon usage
   build-macos-arm64:
     runs-on: macos-11.0
-    strategy:
-      fail-fast: false
     name: "build-macos-11 - arm64"
     steps:
       - uses: actions/checkout@v2
       - name: Install pre-requisites
         # This skips updating brew when installing a package
-        env: HOMEBREW_NO_AUTO_UPDATE=1
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install postgresql@13
           brew services start postgresql

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -144,13 +144,13 @@ jobs:
     name: "build-macos-11 - arm64"
     steps:
       - uses: actions/checkout@v2
-      - name: Install pre-requisites
+      - name: Start postgresql service
         # This skips updating brew when installing a package
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
-          brew install postgresql@13
           brew services start postgresql
+          mkdir repaired_wheels
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
       - uses: pypa/cibuildwheel@v2.1.1

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -150,7 +150,6 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew services start postgresql
-          mkdir repaired_wheels
 
       # This builds all possible Python versions (currently, 3.8 to 3.10)
       - uses: pypa/cibuildwheel@v2.1.1
@@ -159,18 +158,17 @@ jobs:
           CIBW_ARCHS: arm64
           # This changes the default in order to place the wheel in "repaired_wheels"
           # The -w argument requires an absolute path
-          CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}"
+          # CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}"
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
 
       - run: |
           ls -l
           ls -l dist
-          ls -l repaired_wheels
+          ls -l wheelhouse
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: packages_macos_arm64
-          path: |
-            repaired_wheels/*.whl
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -155,6 +155,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: packages_macos
+          name: packages_macos_arm64
           path: |
             dist/*macosx_11_0_arm64.whl

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -141,7 +141,7 @@ jobs:
   # This only uploads the arm64 wheels for Apple M1 Silicon usage
   build-macos-arm64:
     runs-on: macos-11.0
-    name: "build-macos-11 - arm64"
+    name: "build-macos (3.8-3.10, arm64)"
     steps:
       - uses: actions/checkout@v2
       - name: Start postgresql service
@@ -159,9 +159,7 @@ jobs:
           CIBW_ARCHS: arm64
           # This changes the default in order to place the wheel in "repaired_wheels"
           # The -w argument requires an absolute path
-          CIBW_REPAIR_WHEEL_COMMAND: |
-            delocate-listdeps {wheel} &&
-            delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND: "delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w ${{ github.workspace}}/repaired_wheels {wheel}"
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install pre-requisites
         # This skips updating brew when installing a package
-        env: HOMEBREW_NO_AUTO_UPDATE=1 
+        env: HOMEBREW_NO_AUTO_UPDATE=1
         run: |
           brew install postgresql@13
           brew services start postgresql
@@ -162,7 +162,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} -w repaired_wheels {wheel}
           # This allows substitution within setup.py
           PACKAGE_NAME: psycopg2-binary
-      
+
       - run: |
           ls -l
           ls -l dist

--- a/scripts/build/build_macos.sh
+++ b/scripts/build/build_macos.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 set -x
 
-dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-prjdir="$( cd "${dir}/../.." && pwd )"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+prjdir="$(cd "${dir}/../.." && pwd)"
 
 brew install gnu-sed postgresql@13
 
@@ -17,13 +17,13 @@ brew install gnu-sed postgresql@13
 brew services start postgresql
 
 for i in $(seq 10 -1 0); do
-  eval pg_isready && break
-  if [ $i == 0 ]; then
-      echo "PostgreSQL service not ready, giving up"
-      exit 1
-  fi
-  echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
-  sleep 5
+    eval pg_isready && break
+    if [ $i == 0 ]; then
+        echo "PostgreSQL service not ready, giving up"
+        exit 1
+    fi
+    echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
+    sleep 5
 done
 
 # Find psycopg version
@@ -35,15 +35,9 @@ mkdir -p "$distdir"
 # Install required python packages
 pip install -U pip wheel delocate
 
-# Replace the package name
-if [[ "${PACKAGE_NAME:-}" ]]; then
-    gsed -i "s/^setup(name=\"psycopg2\"/setup(name=\"${PACKAGE_NAME}\"/" \
-        "${prjdir}/setup.py"
-fi
-
 # Build the wheels
 wheeldir="${prjdir}/wheels"
-pip wheel -w ${wheeldir} .
+pip wheel --use-feature=in-tree-build -w ${wheeldir} .
 delocate-listdeps ${wheeldir}/*.whl
 
 # Check where is the libpq. I'm gonna kill it for testing

--- a/scripts/build/build_macos.sh
+++ b/scripts/build/build_macos.sh
@@ -19,8 +19,8 @@ brew services start postgresql
 for i in $(seq 10 -1 0); do
   eval pg_isready && break
   if [ $i == 0 ]; then
-        echo "PostgreSQL service not ready, giving up"
-        exit 1
+      echo "PostgreSQL service not ready, giving up"
+      exit 1
   fi
   echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
   sleep 5

--- a/scripts/build/build_macos.sh
+++ b/scripts/build/build_macos.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 set -x
 
-dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-prjdir="$(cd "${dir}/../.." && pwd)"
+dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+prjdir="$( cd "${dir}/../.." && pwd )"
 
 brew install gnu-sed postgresql@13
 
@@ -17,13 +17,13 @@ brew install gnu-sed postgresql@13
 brew services start postgresql
 
 for i in $(seq 10 -1 0); do
-    eval pg_isready && break
-    if [ $i == 0 ]; then
+  eval pg_isready && break
+  if [ $i == 0 ]; then
         echo "PostgreSQL service not ready, giving up"
         exit 1
-    fi
-    echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
-    sleep 5
+  fi
+  echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
+  sleep 5
 done
 
 # Find psycopg version

--- a/scripts/build/build_macos.sh
+++ b/scripts/build/build_macos.sh
@@ -33,7 +33,9 @@ distdir="${prjdir}/dist/psycopg2-$version"
 mkdir -p "$distdir"
 
 # Install required python packages
-pip install -U pip wheel delocate
+pip install -U pip wheel
+# Running it after installing wheel will save building the wheel
+pip install -U delocate
 
 # Build the wheels
 wheeldir="${prjdir}/wheels"
@@ -46,8 +48,10 @@ if [[ -z "${LIBPQ:-}" ]]; then
 fi
 
 delocate-wheel ${wheeldir}/*.whl
-# https://github.com/MacPython/wiki/wiki/Spinning-wheels#question-will-pip-give-me-a-broken-wheel
-delocate-addplat --rm-orig -x 10_9 -x 10_10 ${wheeldir}/*.whl
+if [[ $(uname -m) != 'arm64' ]]; then
+    # https://github.com/MacPython/wiki/wiki/Spinning-wheels#question-will-pip-give-me-a-broken-wheel
+    delocate-addplat --rm-orig -x 10_9 -x 10_10 ${wheeldir}/*.whl
+fi
 cp ${wheeldir}/*.whl ${distdir}
 
 # kill the libpq to make sure tests don't depend on it

--- a/scripts/build/build_macos_arm64.sh
+++ b/scripts/build/build_macos_arm64.sh
@@ -3,10 +3,68 @@
 # Script to generate arm64 wheels on an Apple Silicon host
 #
 # TODO: File issue on why cross-compiling is not working
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -U pip wheel
-pip install cibuildwheel
-# You will be prompted for your password in order to install Python under /Applications
-PACKAGE_NAME=psycopg2-binary
-CIBW_BUILD=cp38-macosx_arm64 cibuildwheel . --output-dir wheelhouse --platform macos 2>&1
+set -euo pipefail
+
+create-venv() {
+    python3 -m venv "${1}"
+    pip install -U pip wheel
+}
+
+tempdir=$(mktemp -d /tmp/psycopg2.$$)
+
+echo "Everything will be created under ${tempdir}"
+
+# create-venv "${tempdir}/venv_cibuildwheel" cibuildwheel
+# source "${tempdir}/venv_cibuildwheel/bin/activate"
+# pip install cibuildwheel
+# export PACKAGE_NAME=psycopg2-binary
+# # When you see "Repairing wheel" you will see this output when executing in an Apple Silicon
+# # /opt/homebrew/Cellar/openssl@1.1/1.1.1l/lib/libcrypto.1.1.dylib
+# # /opt/homebrew/Cellar/openssl@1.1/1.1.1l/lib/libssl.1.1.dylib
+# # /opt/homebrew/Cellar/postgresql/13.4/lib/libpq.5.13.dylib
+# # If you don't specify --output-dir you will be prompted for sudo
+# CIBW_BUILD=cp38-macosx_arm64 cibuildwheel . --output-dir "${tempdir}/wheelhouse" --platform macos 2>&1
+# # This package should be close to 2MB rather than 140KB
+# du -h wheelhouse/*.whl
+# deactivate
+
+create-venv "${tempdir}/venv_delocate"
+source "${tempdir}/venv_delocate/bin/activate"
+pip install delocate
+export PACKAGE_NAME=psycopg2-binary
+# I'm making the steps close to what cibuildwheel does
+pip wheel --use-feature=in-tree-build --wheel-dir "${tempdir}/built_wheel" --no-deps .
+set -x
+delocate-listdeps "${tempdir}/built_wheel/*.whl"
+delocate-wheel --require-archs arm64 \
+    -w "${tempdir}/repaired_wheel" \
+    "${tempdir}/built_wheel/*.whl"
+# This should be around 140KB
+du -h "${tempdir}/built_wheel/*.whl" || exit 0
+# This package should be close to 2MB rather than 140KB
+du -h "${tempdir}/repaired_wheel/*"
+deactivate
+
+# Start the database for testing
+# brew services start postgresql
+
+# for i in $(seq 10 -1 0); do
+#     eval pg_isready && break
+#     if [ $i == 0 ]; then
+#         echo "PostgreSQL service not ready, giving up"
+#         exit 1
+#     fi
+#     echo "PostgreSQL service not ready, waiting a bit, attempts left: $i"
+#     sleep 5
+# done
+# create-venv "${tempdir}/venv_test_package"
+# source "${tempdir}/venv_test_package/bin/activate"
+# export PSYCOPG2_TESTDB=postgres
+# export PSYCOPG2_TEST_FAST=1
+# # pip install psycopg2-binary --no-index -f "${tempdir}/wheelhouse"
+# pip install psycopg2-binary --no-index -f wheelhouse
+# python -c "import psycopg2; print(psycopg2.__version__)"
+# python -c "import psycopg2; print(psycopg2.__libpq_version__)"
+# python -c "import psycopg2; print(psycopg2.extensions.libpq_version())"
+# python -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"
+# deactivate

--- a/scripts/build/build_macos_arm64.sh
+++ b/scripts/build/build_macos_arm64.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Script to generate arm64 wheels on an Apple Silicon host
+#
+# TODO: File issue on why cross-compiling is not working
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip wheel
+pip install cibuildwheel
+# You will be prompted for your password in order to install Python under /Applications
+PACKAGE_NAME=psycopg2-binary
+CIBW_BUILD=cp38-macosx_arm64 cibuildwheel . --output-dir wheelhouse --platform macos 2>&1

--- a/scripts/build/test_macos_arm64.sh
+++ b/scripts/build/test_macos_arm64.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Test macos arm64 wheel packages from Github actions.
+# It only makes sense to run this script from an Apple Silicon device
+#
+# From Github's Actions tab, choose the "Build packages" run and
+# look for artifacts at the bottom. Download "packages_macos_arm64"
+# and call this script with the path to it
+set -euo pipefail
+set -x
+
+url=

--- a/scripts/build/test_macos_arm64.sh
+++ b/scripts/build/test_macos_arm64.sh
@@ -9,4 +9,15 @@
 set -euo pipefail
 set -x
 
-url=
+tempdir=$(mktemp -d /tmp/psycopg2.$$)
+venv="$tempdir/venv"
+unzip "$1" -d "$tempdir"
+
+# XXX: It would be ideal to run this script against various Python versions
+python3 -m venv "$venv"
+source "$venv/bin/activate"
+pip install psycopg2-binary --no-index -f dist
+python -c "import psycopg2; print(psycopg2.__version__)"
+python -c "import psycopg2; print(psycopg2.__libpq_version__)"
+python -c "import psycopg2; print(psycopg2.extensions.libpq_version())"
+python -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ except ImportError:
 # for a consistent versioning pattern.
 
 PSYCOPG_VERSION = '2.9.1'
+PSYCOPG_NAME = os.environ.get("PACKAGE_NAME", "psycopg2")
 
 
 # note: if you are changing the list of supported Python version please fix
@@ -545,7 +546,7 @@ except Exception:
     print("failed to read readme: ignoring...")
     readme = __doc__
 
-setup(name="psycopg2",
+setup(name=PSYCOPG_NAME,
       version=PSYCOPG_VERSION,
       author="Federico Di Gregorio",
       author_email="fog@initd.org",


### PR DESCRIPTION
This uses [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) in order to cross-compile the arm64 wheels for Python 3.8, 3.9 & 3.10.

Fixes psycopg#1286