### PR TITLE
Test out Python 3.10 support

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout repos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,14 @@ jobs:
             postgres: 12
           - python: 3.9
             postgres: 13
+          - python: 3.10
+            postgres: 13
 
           # Opposite extremes of the supported Py/PG range, other architecture
           - python: 3.6
             postgres: 13
             architecture: 'x86'
-          - python: 3.9
+          - python: 3.10
             postgres: 9.5
             architecture: 'x86'
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -131,7 +131,7 @@ The current `!psycopg2` implementation supports:
 ..
     NOTE: keep consistent with setup.py and the /features/ page.
 
-- Python versions from 3.6 to 3.9
+- Python versions from 3.6 to 3.10
 - PostgreSQL server versions from 7.4 to 13
 - PostgreSQL client library version from 9.1
 

--- a/scripts/build/appveyor.py
+++ b/scripts/build/appveyor.py
@@ -655,9 +655,9 @@ class Options:
 
     @property
     def py_ver(self):
-        """The Python version to build as 2 digits string."""
+        """The Python version to build as 2-3 digits string."""
         rv = os.environ['PY_VER']
-        assert rv in ('36', '37', '38', '39'), rv
+        assert rv in ('36', '37', '38', '39', '310'), rv
         return rv
 
     @property
@@ -737,12 +737,13 @@ class Options:
         # https://wiki.python.org/moin/WindowsCompilers
         # https://www.appveyor.com/docs/windows-images-software/#python
         # Py 3.6--3.8 = VS Ver. 14.0 (VS 2015)
-        # Py 3.9 = VS Ver. 16.0 (VS 2019)
+        # Py 3.9--3.10 = VS Ver. 16.0 (VS 2019)
         vsvers = {
             '36': '14.0',
             '37': '14.0',
             '38': '14.0',
             '39': '16.0',
+            '310': '16.0',
         }
         return vsvers[self.py_ver]
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: C

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {3.6,3.7,3.8,3.9}
+envlist = {3.6,3.7,3.8,3.9,3.10}
 
 [testenv]
 commands = make check


### PR DESCRIPTION
Will probably need to wait for appveyor windows-images to support python
3.10, but see if any other issues can be flushed out.