### PR TITLE
make tox use expected python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tests
-        run: tox -e ${{ matrix.python }}
+        run: tox -e py$(sed -e 's/\.//' <<< ${{ matrix.python }})
         timeout-minutes: 5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {3.6,3.7,3.8,3.9,3.10}
+envlist = py{36,37,38,39,310}
 
 [testenv]
 commands = make check


### PR DESCRIPTION
Hi,


when running tox with the default envlist, it does not use the python I expect from tox.ini.

replacing `commands` with `python -V` in tox.ini, notice it's always Python 3.10.0:

```console
$ tox
GLOB sdist-make: /home/cyril/work/psycopg2/setup.py
3.6 create: /home/cyril/work/psycopg2/.tox/3.6
3.6 inst: /home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
3.6 installed: psycopg2 @ file:///home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
3.6 run-test-pre: PYTHONHASHSEED='231627133'
3.6 run-test: commands[0] | python -V
Python 3.10.0
3.7 create: /home/cyril/work/psycopg2/.tox/3.7
3.7 inst: /home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
3.7 installed: psycopg2 @ file:///home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
3.7 run-test-pre: PYTHONHASHSEED='231627133'
3.7 run-test: commands[0] | python -V
Python 3.10.0
...
```

but using the syntax described in [tox docs](https://tox.wiki/en/latest/config.html#tox-environments),
we get the expected behaviour:

```console
$ tox
GLOB sdist-make: /home/cyril/work/psycopg2/setup.py
py36 create: /home/cyril/work/psycopg2/.tox/py36
ERROR: InterpreterNotFound: python3.6
py37 create: /home/cyril/work/psycopg2/.tox/py37
ERROR: InterpreterNotFound: python3.7
py38 create: /home/cyril/work/psycopg2/.tox/py38
ERROR: InterpreterNotFound: python3.8
py39 create: /home/cyril/work/psycopg2/.tox/py39
py39 inst: /home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
py39 installed: psycopg2 @ file:///home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
py39 run-test-pre: PYTHONHASHSEED='487652293'
py39 run-test: commands[0] | python -V
Python 3.9.7
py310 create: /home/cyril/work/psycopg2/.tox/py310
py310 inst: /home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
py310 installed: psycopg2 @ file:///home/cyril/work/psycopg2/.tox/.tmp/package/1/psycopg2-2.9.1.zip
py310 run-test-pre: PYTHONHASHSEED='487652293'
py310 run-test: commands[0] | python -V
Python 3.10.0
```
