### PR TITLE
python 3.11 support

### DIFF
--- a/.appveyor/packages.yml
+++ b/.appveyor/packages.yml
@@ -11,6 +11,8 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/windows-images-software/#python
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "38", PY_ARCH: "32"}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -75,7 +75,7 @@ jobs:
           docker run --rm
           -e PLAT=${{ matrix.tag }}_${{ matrix.arch }}
           -e PACKAGE_NAME=psycopg2-binary
-          -e PYVERS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+          -e PYVERS="cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
           -e PSYCOPG2_TESTDB=postgres
           -e PSYCOPG2_TESTDB_HOST=172.17.0.1
           -e PSYCOPG2_TESTDB_USER=postgres
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout repos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,22 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: 3.6
-            postgres: 10
-          - python: 3.7
-            postgres: 11
-          - python: 3.8
-            postgres: 12
-          - python: 3.9
-            postgres: 13
+          - {python: "3.6", postgres: "10"}
+          - {python: "3.7", postgres: "11"}
+          - {python: "3.8", postgres: "12"}
+          - {python: "3.9", postgres: "13"}
+          - {python: "3.10", postgres: "14"}
 
           # Opposite extremes of the supported Py/PG range, other architecture
-          - python: 3.6
-            postgres: 13
-            architecture: 'x86'
-          - python: 3.9
-            postgres: 9.5
-            architecture: 'x86'
+          - {python: "3.6", postgres: "14", architecture: "x86"}
+          - {python: "3.7", postgres: "13", architecture: "x86"}
+          - {python: "3.8", postgres: "12", architecture: "x86"}
+          - {python: "3.9", postgres: "11", architecture: "x86"}
+          - {python: "3.10", postgres: "10", architecture: "x86"}
 
     env:
       PSYCOPG2_TESTDB: postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - {python: "3.8", postgres: "12"}
           - {python: "3.9", postgres: "13"}
           - {python: "3.10", postgres: "14"}
+          - {python: "3.11-dev", postgres: "14"}
 
           # Opposite extremes of the supported Py/PG range, other architecture
           - {python: "3.6", postgres: "14", architecture: "x86"}
@@ -25,6 +26,7 @@ jobs:
           - {python: "3.8", postgres: "12", architecture: "x86"}
           - {python: "3.9", postgres: "11", architecture: "x86"}
           - {python: "3.10", postgres: "10", architecture: "x86"}
+          - {python: "3.11-dev", postgres: "10", architecture: "x86"}
 
     env:
       PSYCOPG2_TESTDB: postgres
@@ -48,11 +50,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install tox
-        run: pip install tox
       - name: Run tests
-        run: tox -e ${{ matrix.python }}
+        env:
+          MATRIX_PYTHON: ${{ matrix.python }}
+        run: tox -e ${MATRIX_PYTHON%-dev}
         timeout-minutes: 5

--- a/psycopg/connection_int.c
+++ b/psycopg/connection_int.c
@@ -33,6 +33,7 @@
 #include "psycopg/green.h"
 #include "psycopg/notify.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 /* String indexes match the ISOLATION_LEVEL_* consts */

--- a/psycopg/connection_type.c
+++ b/psycopg/connection_type.c
@@ -35,6 +35,7 @@
 #include "psycopg/green.h"
 #include "psycopg/xid.h"
 
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 

--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -47,6 +47,7 @@
 #include "psycopg/libpq_support.h"
 #include "libpq-fe.h"
 
+#include <stdlib.h>
 #ifdef _WIN32
 /* select() */
 #include <winsock2.h>

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -57,6 +57,8 @@
 #include <datetime.h>
 #include "psycopg/adapter_datetime.h"
 
+#include <stdlib.h>
+
 HIDDEN PyObject *psycoEncodings = NULL;
 HIDDEN PyObject *sqlstate_errors = NULL;
 

--- a/psycopg/replication_connection_type.c
+++ b/psycopg/replication_connection_type.c
@@ -129,6 +129,11 @@ replicationConnection_repr(replicationConnectionObject *self)
         self, self->conn.dsn, self->conn.closed);
 }
 
+static int
+replicationConnectionType_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return connectionType.tp_traverse(self, visit, arg);
+}
 
 /* object calculated member list */
 
@@ -173,7 +178,7 @@ PyTypeObject replicationConnectionType = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_ITER |
       Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     replicationConnectionType_doc, /*tp_doc*/
-    0,          /*tp_traverse*/
+    replicationConnectionType_traverse, /*tp_traverse*/
     0,          /*tp_clear*/
     0,          /*tp_richcompare*/
     0,          /*tp_weaklistoffset*/

--- a/psycopg/replication_cursor_type.c
+++ b/psycopg/replication_cursor_type.c
@@ -346,6 +346,11 @@ replicationCursor_repr(replicationCursorObject *self)
         "<ReplicationCursor object at %p; closed: %d>", self, self->cur.closed);
 }
 
+static int
+replicationCursorType_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return cursorType.tp_traverse(self, visit, arg);
+}
 
 /* object type */
 
@@ -374,7 +379,7 @@ PyTypeObject replicationCursorType = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_ITER |
       Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     replicationCursorType_doc, /*tp_doc*/
-    0,          /*tp_traverse*/
+    replicationCursorType_traverse, /*tp_traverse*/
     0,          /*tp_clear*/
     0,          /*tp_richcompare*/
     0,          /*tp_weaklistoffset*/

--- a/scripts/build/appveyor.py
+++ b/scripts/build/appveyor.py
@@ -661,7 +661,7 @@ class Options:
     def py_ver(self):
         """The Python version to build as 2 digits string."""
         rv = os.environ['PY_VER']
-        assert rv in ('36', '37', '38', '39'), rv
+        assert rv in ('36', '37', '38', '39', '310'), rv
         return rv
 
     @property
@@ -747,6 +747,7 @@ class Options:
             '37': '14.0',
             '38': '14.0',
             '39': '16.0',
+            '310': '16.0',
         }
         return vsvers[self.py_ver]
 

--- a/scripts/build/build_manylinux_2_24.sh
+++ b/scripts/build/build_manylinux_2_24.sh
@@ -27,7 +27,7 @@ if [[ "${PACKAGE_NAME:-}" ]]; then
 fi
 
 # Install prerequisite libraries
-curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+curl -k -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 echo "deb http://apt.postgresql.org/pub/repos/apt stretch-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 apt-get -y update

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {3.6,3.7,3.8,3.9}
+envlist = {3.6,3.7,3.8,3.9,3.10}
 
 [testenv]
 commands = make check

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = {3.6,3.7,3.8,3.9,3.10}
+envlist = {3.6,3.7,3.8,3.9,3.10,3.11}
 
 [testenv]
 commands = make check
 whitelist_externals = make
 passenv = PG* PSYCOPG2_TEST*
+basepython = python{envname}
 
 [flake8]
 max-line-length = 85


### PR DESCRIPTION
preliminary [python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html) support:

* The <Python.h> header file no longer includes <stdlib.h>. C extensions using <stdlib.h> must now include it explicitly. The system <stdlib.h> header provides functions like: malloc()/free(), getenv(), strtol(), abs(), strtol(), exit() and abort(). (Contributed by Victor Stinner in bpo-45434.)
* The PyType_Ready() function now raises an error if a type is defined with the Py_TPFLAGS_HAVE_GC flag set but has no traverse function (PyTypeObject.tp_traverse). (Contributed by Victor Stinner in bpo-44263.)