### PR TITLE
Build `musllinux` wheels

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-installing-psycopg2.md
+++ b/.github/ISSUE_TEMPLATE/problem-installing-psycopg2.md
@@ -14,7 +14,6 @@ If you have a question, such has "how do you do X with Python/PostgreSQL/psycopg
 - [ ] I am running the latest version of pip, i.e. typing ``pip --version`` you get [this version](https://pypi.org/project/pip/).
 - [ ] I have read the [installation documentation](https://www.psycopg.org/docs/install.html) and the [frequently asked questions](https://www.psycopg.org/docs/faq.html)
 - [ ] I am not trying to install `psycopg2-binary` on an Apple M1, for which [binary packages are not supported](https://github.com/psycopg/psycopg2/issues/1286)
-- [ ] I am not trying to install `psycopg2-binary` in an Alpine Linux Docker image
 - [ ] If install failed, I typed `pg_config` on the command line and I obtained an output instead of an error.
 
 **Please complete the following information:**

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -61,6 +61,10 @@ jobs:
           - {tag: manylinux2014, arch: i686}
           - {tag: manylinux_2_24, arch: aarch64}
           - {tag: manylinux_2_24, arch: ppc64le}
+          - {tag: musllinux_1_1, arch: x86_64}
+          - {tag: musllinux_1_1, arch: i686}
+          - {tag: musllinux_1_1, arch: aarch64}
+          - {tag: musllinux_1_1, arch: ppc64le}
 
     runs-on: ubuntu-20.04
     steps:

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 Current release
 ---------------
 
+What's new in psycopg 2.9.3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Alpine (musl) wheels now available (:ticket:`#1148`).
+
 What's new in psycopg 2.9.2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scripts/build/build_musllinux_1_1.sh
+++ b/scripts/build/build_musllinux_1_1.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Create musllinux_1_1 wheels for psycopg2
+#
+# Look at the .github/workflows/packages.yml file for hints about how to use it.
+
+set -euo pipefail
+set -x
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+prjdir="$( cd "${dir}/../.." && pwd )"
+
+# Build all the available versions, or just the ones specified in PYVERS
+if [ ! "${PYVERS:-}" ]; then
+    PYVERS="$(ls /opt/python/)"
+fi
+
+# Find psycopg version
+version=$(grep -e ^PSYCOPG_VERSION "${prjdir}/setup.py" | sed "s/.*'\(.*\)'/\1/")
+# A gratuitous comment to fix broken vim syntax file: '")
+distdir="${prjdir}/dist/psycopg2-$version"
+
+# Replace the package name
+if [[ "${PACKAGE_NAME:-}" ]]; then
+    sed -i "s/^setup(name=\"psycopg2\"/setup(name=\"${PACKAGE_NAME}\"/" \
+        "${prjdir}/setup.py"
+fi
+
+# Install prerequisite libraries
+apk update
+apk add postgresql-dev
+# Add findutils because the Busybox version lacks the `-ls` flag, used by the
+# `strip_wheel.sh` script.
+apk add findutils
+
+# Create the wheel packages
+for pyver in $PYVERS; do
+    pybin="/opt/python/${pyver}/bin"
+    "${pybin}/python" -m build -w -o "${prjdir}/dist/" "${prjdir}"
+done
+
+# Bundle external shared libraries into the wheels
+for whl in "${prjdir}"/dist/*.whl; do
+    "${dir}/strip_wheel.sh" "$whl"
+    auditwheel repair "$whl" -w "$distdir"
+done
+
+# Make sure the postgresql-dev is not in the system
+apk del postgresql-dev
+
+# Install packages and test
+cd "${prjdir}"
+for pyver in $PYVERS; do
+    pybin="/opt/python/${pyver}/bin"
+    "${pybin}/pip" install ${PACKAGE_NAME:-psycopg2} --no-index -f "$distdir"
+
+    # Print psycopg and libpq versions
+    "${pybin}/python" -c "import psycopg2; print(psycopg2.__version__)"
+    "${pybin}/python" -c "import psycopg2; print(psycopg2.__libpq_version__)"
+    "${pybin}/python" -c "import psycopg2; print(psycopg2.extensions.libpq_version())"
+
+    # Fail if we are not using the expected libpq library
+    if [[ "${WANT_LIBPQ:-}" ]]; then
+        "${pybin}/python" -c "import psycopg2, sys; sys.exit(${WANT_LIBPQ} != psycopg2.extensions.libpq_version())"
+    fi
+
+    "${pybin}/python" -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"
+done


### PR DESCRIPTION
I'm back for some more `musllinux` support. Since psycopg2 is still needed for Django, I figured I'd try to add support here as well.

The artifacts can be found here: https://github.com/lithammer/psycopg2/actions/runs/1564148387