### PR TITLE
Fix segmentation fault for instantiating `psycopg2.extensions.Column`

### DIFF
--- a/psycopg/column_type.c
+++ b/psycopg/column_type.c
@@ -111,7 +111,7 @@ column_init(columnObject *self, PyObject *args, PyObject *kwargs)
         "name", "type_code", "display_size", "internal_size",
         "precision", "scale", "null_ok", "table_oid", "table_column", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OOOOOOOOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|UOOOOOOOO", kwlist,
             &name, &type_code, &display_size, &internal_size, &precision,
             &scale, &null_ok, &table_oid, &table_column)) {
         return -1;


### PR DESCRIPTION
More information can be found in the issue created [here](https://github.com/psycopg/psycopg2/issues/1402).

Now, the column object no longer segfaults as `PyArg_ParseTupleAndKeywords` is able to correctly identify the input as unicode (or `None`, as used in `_make_column` in `pqpath.c`).

How I tested it:
```
>>> from psycopg2.extensions import Column
>>> for _ in range(1000000):
...     Column("abcdefghijklmnopq")
```

After eventually finishing, the program did not segfault. I think 1 million instantiations is enough of a safe bet here.