### PR TITLE
Unskip tests that work on CockroachDB v22.1

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -390,6 +390,7 @@ class AsyncTests(ConnectingTestCase):
         # fetching from the correct cursor works
         self.assertEquals(cur1.fetchone()[0], 1)
 
+    @skip_if_crdb("batch statements", version="< 22.1")
     def test_error(self):
         cur = self.conn.cursor()
         cur.execute("insert into table1 values (%s)", (1, ))
@@ -402,9 +403,8 @@ class AsyncTests(ConnectingTestCase):
         # this should fail as well (Postgres behaviour)
         self.assertRaises(psycopg2.IntegrityError, self.wait, cur)
         # but this should work
-        if crdb_version(self.sync_conn) is None:
-            cur.execute("insert into table1 values (%s)", (2, ))
-            self.wait(cur)
+        cur.execute("insert into table1 values (%s)", (2, ))
+        self.wait(cur)
         # and the cursor should be usable afterwards
         cur.execute("insert into table1 values (%s)", (3, ))
         self.wait(cur)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -412,7 +412,7 @@ class CursorTests(ConnectingTestCase):
         self.assert_(curs.pgresult_ptr is None)
 
 
-@skip_if_crdb("named cursor")
+@skip_if_crdb("named cursor", version="< 22.1")
 class NamedCursorTests(ConnectingTestCase):
     def test_invalid_name(self):
         curs = self.conn.cursor()
@@ -436,6 +436,7 @@ class NamedCursorTests(ConnectingTestCase):
             curs.execute("insert into withhold values (%s)", (i,))
         curs.close()
 
+    @skip_if_crdb("cursor with hold")
     def test_withhold(self):
         self.assertRaises(psycopg2.ProgrammingError, self.conn.cursor,
                           withhold=True)
@@ -460,6 +461,7 @@ class NamedCursorTests(ConnectingTestCase):
         curs.execute("drop table withhold")
         self.conn.commit()
 
+    @skip_if_crdb("cursor with hold")
     def test_withhold_no_begin(self):
         self._create_withhold_table()
         curs = self.conn.cursor("w", withhold=True)
@@ -484,6 +486,7 @@ class NamedCursorTests(ConnectingTestCase):
         self.assertEqual(self.conn.info.transaction_status,
                          psycopg2.extensions.TRANSACTION_STATUS_IDLE)
 
+    @skip_if_crdb("cursor with hold")
     def test_withhold_autocommit(self):
         self._create_withhold_table()
         self.conn.commit()
@@ -506,6 +509,7 @@ class NamedCursorTests(ConnectingTestCase):
         self.assertEqual(self.conn.info.transaction_status,
                          psycopg2.extensions.TRANSACTION_STATUS_IDLE)
 
+    @skip_if_crdb("scroll cursor")
     def test_scrollable(self):
         self.assertRaises(psycopg2.ProgrammingError, self.conn.cursor,
                           scrollable=True)
@@ -679,6 +683,7 @@ class NamedCursorTests(ConnectingTestCase):
         self.assertRaises((IndexError, psycopg2.ProgrammingError),
             cur.scroll, 1)
 
+    @skip_if_crdb("scroll cursor")
     @skip_before_postgres(8, 0)
     def test_scroll_named(self):
         cur = self.conn.cursor('tmp', scrollable=True)

--- a/tests/test_extras_dictcursor.py
+++ b/tests/test_extras_dictcursor.py
@@ -64,7 +64,7 @@ class _DictCursorBase(ConnectingTestCase):
 class ExtrasDictCursorTests(_DictCursorBase):
     """Test if DictCursor extension class works."""
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def testDictConnCursorArgs(self):
         self.conn.close()
         self.conn = self.connect(connection_factory=psycopg2.extras.DictConnection)
@@ -132,19 +132,19 @@ class ExtrasDictCursorTests(_DictCursorBase):
                 return row
         self._testWithNamedCursor(getter)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("greedy cursor")
     @skip_before_postgres(8, 2)
     def testDictCursorWithNamedCursorNotGreedy(self):
         curs = self.conn.cursor('tmp', cursor_factory=psycopg2.extras.DictCursor)
         self._testNamedCursorNotGreedy(curs)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     @skip_before_postgres(8, 0)
     def testDictCursorWithNamedCursorIterRowNumber(self):
         curs = self.conn.cursor('tmp', cursor_factory=psycopg2.extras.DictCursor)
         self._testIterRowNumber(curs)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def _testWithNamedCursor(self, getter):
         curs = self.conn.cursor('aname', cursor_factory=psycopg2.extras.DictCursor)
         curs.execute("SELECT * FROM ExtrasDictCursorTests")
@@ -285,19 +285,19 @@ class ExtrasDictCursorRealTests(_DictCursorBase):
                 return row
         self._testWithNamedCursorReal(getter)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("greedy cursor")
     @skip_before_postgres(8, 2)
     def testDictCursorRealWithNamedCursorNotGreedy(self):
         curs = self.conn.cursor('tmp', cursor_factory=psycopg2.extras.RealDictCursor)
         self._testNamedCursorNotGreedy(curs)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     @skip_before_postgres(8, 0)
     def testDictCursorRealWithNamedCursorIterRowNumber(self):
         curs = self.conn.cursor('tmp', cursor_factory=psycopg2.extras.RealDictCursor)
         self._testIterRowNumber(curs)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def _testWithNamedCursorReal(self, getter):
         curs = self.conn.cursor('aname',
             cursor_factory=psycopg2.extras.RealDictCursor)
@@ -376,7 +376,7 @@ class NamedTupleCursorTest(ConnectingTestCase):
         curs.execute("INSERT INTO nttest VALUES (3, 'baz')")
         self.conn.commit()
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_cursor_args(self):
         cur = self.conn.cursor('foo', cursor_factory=psycopg2.extras.DictCursor)
         self.assertEqual(cur.name, 'foo')
@@ -533,7 +533,7 @@ class NamedTupleCursorTest(ConnectingTestCase):
         finally:
             NamedTupleCursor._make_nt = f_orig
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     @skip_before_postgres(8, 0)
     def test_named(self):
         curs = self.conn.cursor('tmp')
@@ -544,28 +544,28 @@ class NamedTupleCursorTest(ConnectingTestCase):
         recs.extend(curs.fetchall())
         self.assertEqual(list(range(10)), [t.i for t in recs])
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_named_fetchone(self):
         curs = self.conn.cursor('tmp')
         curs.execute("""select 42 as i""")
         t = curs.fetchone()
         self.assertEqual(t.i, 42)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_named_fetchmany(self):
         curs = self.conn.cursor('tmp')
         curs.execute("""select 42 as i""")
         recs = curs.fetchmany(10)
         self.assertEqual(recs[0].i, 42)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_named_fetchall(self):
         curs = self.conn.cursor('tmp')
         curs.execute("""select 42 as i""")
         recs = curs.fetchall()
         self.assertEqual(recs[0].i, 42)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("greedy cursor")
     @skip_before_postgres(8, 2)
     def test_not_greedy(self):
         curs = self.conn.cursor('tmp')
@@ -580,7 +580,7 @@ class NamedTupleCursorTest(ConnectingTestCase):
         self.assert_(recs[1].ts - recs[0].ts < timedelta(seconds=0.005))
         self.assert_(recs[2].ts - recs[1].ts > timedelta(seconds=0.0099))
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     @skip_before_postgres(8, 0)
     def test_named_rownumber(self):
         curs = self.conn.cursor('tmp')

--- a/tests/test_green.py
+++ b/tests/test_green.py
@@ -219,7 +219,7 @@ class CallbackErrorTestCase(ConnectingTestCase):
 
         self.fail("you should have had a success or an error by now")
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_errors_named_cursor(self):
         for i in range(100):
             self.to_error = None

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -290,7 +290,7 @@ class WithCursorTestCase(WithTestCase):
         self.assert_(curs.closed)
         self.assert_(closes)
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     def test_exception_swallow(self):
         # bug #262: __exit__ calls cur.close() that hides the exception
         # with another error.
@@ -304,7 +304,7 @@ class WithCursorTestCase(WithTestCase):
         else:
             self.fail("where is my exception?")
 
-    @skip_if_crdb("named cursor")
+    @skip_if_crdb("named cursor", version="< 22.1")
     @skip_before_postgres(8, 2)
     def test_named_with_noop(self):
         with self.conn.cursor('named'):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -467,11 +467,13 @@ def skip_if_crdb(reason, conn=None, version=None):
 crdb_reasons = {
     "2-phase commit": 22329,
     "backend pid": 35897,
+    "batch statements": 44803,
     "cancel": 41335,
     "cast adds tz": 51692,
     "cidr": 18846,
     "composite": 27792,
     "copy": 41608,
+    "cursor with hold": 77101,
     "deferrable": 48307,
     "encoding": 35882,
     "hstore": 41284,
@@ -483,6 +485,7 @@ crdb_reasons = {
     "notify": 41522,
     "password_encryption": 42519,
     "range": 41282,
+    "scroll cursor": 77102,
     "stored procedure": 1751,
 }
 


### PR DESCRIPTION
CockroachDB supports named cursors in v22.1, so more tests pass.