### PR TITLE
Move to manylinux_2_28 for aarch64, ppc64le builds.

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -59,8 +59,8 @@ jobs:
         include:
           - {tag: manylinux2014, arch: x86_64}
           - {tag: manylinux2014, arch: i686}
-          - {tag: manylinux_2_24, arch: aarch64}
-          - {tag: manylinux_2_24, arch: ppc64le}
+          - {tag: manylinux_2_28, arch: aarch64}
+          - {tag: manylinux_2_28, arch: ppc64le}
           - {tag: musllinux_1_1, arch: x86_64}
           - {tag: musllinux_1_1, arch: i686}
           - {tag: musllinux_1_1, arch: aarch64}

--- a/scripts/build/build_manylinux_2_28.sh
+++ b/scripts/build/build_manylinux_2_28.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Create manylinux_2_24 wheels for psycopg2
+# Create manylinux_2_28 wheels for psycopg2
 #
 # Look at the .github/workflows/packages.yml file for hints about how to use it.
 
@@ -28,7 +28,7 @@ fi
 
 # Install prerequisite libraries
 curl -k -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-echo "deb http://apt.postgresql.org/pub/repos/apt stretch-pgdg main" \
+echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 apt-get -y update
 apt-get install -y libpq-dev

--- a/scripts/build/build_manylinux_2_28.sh
+++ b/scripts/build/build_manylinux_2_28.sh
@@ -27,11 +27,7 @@ if [[ "${PACKAGE_NAME:-}" ]]; then
 fi
 
 # Install prerequisite libraries
-curl -k -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" \
-    > /etc/apt/sources.list.d/pgdg.list
-apt-get -y update
-apt-get install -y libpq-dev
+yum install -y libpq-devel
 
 # Create the wheel packages
 for pyver in $PYVERS; do


### PR DESCRIPTION
Related to: 
- https://github.com/psycopg/psycopg2/issues/1396 (hopefully getting newer libpq binaries)
- https://github.com/pypa/manylinux/issues/1332 (2_24 being EOL?)
- https://github.com/mayeut/pep600_compliance#distro-compatibility (2_28 compatible base to Debian 10)
- https://github.com/pypa/manylinux/commit/26ca99408eb9d728f355894613d02b28d9d28d1d (2_28 just being added to the build pipeline for manylinux)

I _believe_ this should be the only thing necessary to get to Debian 10 (Buster)

For what it's worth this _MAY_ be able to collapse the CentOS builds from `manylinux2014` to `manylinux_2_28` as per the compatibility chart above states it supports a minimum of CentOS 8, although I don't want to trigger pitchforks: https://github.com/pypa/manylinux/issues/1332#issuecomment-1148055207

---

I also may be completely missing the issue here. 🤷 Feel free to decline with fervor.