### PR TITLE
AppVeyor: Visual Studio 2022 testing fails

### DIFF
--- a/.appveyor/packages.yml
+++ b/.appveyor/packages.yml
@@ -11,7 +11,6 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/windows-images-software/#python
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}

--- a/.appveyor/packages.yml
+++ b/.appveyor/packages.yml
@@ -11,6 +11,7 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/windows-images-software/#python
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}

--- a/.appveyor/tests.yml
+++ b/.appveyor/tests.yml
@@ -6,6 +6,7 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/windows-images-software/#python
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}

--- a/.appveyor/tests.yml
+++ b/.appveyor/tests.yml
@@ -6,7 +6,6 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/windows-images-software/#python
-        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "310", PY_ARCH: "64"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}


### PR DESCRIPTION
`.appveyor/packages.yml` is the active file.
`.appveyor/tests.yml` is the inactive file.

For Python versions available on Appveyor, see
https://www.appveyor.com/docs/windows-images-software/#python