### PR TITLE
Remove `__nonzero__` method

### DIFF
--- a/lib/_range.py
+++ b/lib/_range.py
@@ -143,10 +143,6 @@ class Range:
     def __bool__(self):
         return self._bounds is not None
 
-    def __nonzero__(self):
-        # Python 2 compatibility
-        return type(self).__bool__(self)
-
     def __eq__(self, other):
         if not isinstance(other, Range):
             return False


### PR DESCRIPTION
It is not used in python3, but python2 is no longer supported: https://github.com/python-babel/babel/blob/d8584405a66a79d79bed44b5d80df0bc89f8eee3/setup.py#L59