### PR TITLE
Add executemany & execute_batch examples

### DIFF
--- a/doc/src/cursor.rst
+++ b/doc/src/cursor.rst
@@ -207,10 +207,12 @@ The ``cursor`` class
 
         Parameters are bounded to the query using the same rules described in
         the `~cursor.execute()` method.
-        
+
+        .. code:: python
+
             >>> nums = ((1,), (5,), (10,))
             >>> cur.executemany("INSERT INTO test (num) VALUES (%s)", nums)
-            
+
             >>> tuples = ((123, "foo"), (42, "bar"), (23, "baz"))
             >>> cur.executemany("INSERT INTO test (num, data) VALUES (%s, %s)", tuples)
 

--- a/doc/src/cursor.rst
+++ b/doc/src/cursor.rst
@@ -207,6 +207,12 @@ The ``cursor`` class
 
         Parameters are bounded to the query using the same rules described in
         the `~cursor.execute()` method.
+        
+            >>> nums = ((1,), (5,), (10,))
+            >>> cur.executemany("INSERT INTO test (num) VALUES (%s)", nums)
+            
+            >>> tuples = ((123, "foo"), (42, "bar"), (23, "baz"))
+            >>> cur.executemany("INSERT INTO test (num, data) VALUES (%s, %s)", tuples)
 
         .. warning::
             In its current implementation this method is not faster than

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -1029,11 +1029,13 @@ parameters.  By reducing the number of server roundtrips the performance can be
 
 .. autofunction:: execute_batch
 
-    >>> nums = ((1,), (5,), (10,))
-    >>> execute_batch(cur, "INSERT INTO test (num) VALUES (%s)", nums)
-            
-    >>> tuples = ((123, "foo"), (42, "bar"), (23, "baz"))
-    >>> execute_batch(cur, "INSERT INTO test (num, data) VALUES (%s, %s)", tuples)
+    .. code:: python
+
+        >>> nums = ((1,), (5,), (10,))
+        >>> execute_batch(cur, "INSERT INTO test (num) VALUES (%s)", nums)
+
+        >>> tuples = ((123, "foo"), (42, "bar"), (23, "baz"))
+        >>> execute_batch(cur, "INSERT INTO test (num, data) VALUES (%s, %s)", tuples)
 
     .. versionadded:: 2.7
 

--- a/doc/src/extras.rst
+++ b/doc/src/extras.rst
@@ -1029,6 +1029,12 @@ parameters.  By reducing the number of server roundtrips the performance can be
 
 .. autofunction:: execute_batch
 
+    >>> nums = ((1,), (5,), (10,))
+    >>> execute_batch(cur, "INSERT INTO test (num) VALUES (%s)", nums)
+            
+    >>> tuples = ((123, "foo"), (42, "bar"), (23, "baz"))
+    >>> execute_batch(cur, "INSERT INTO test (num, data) VALUES (%s, %s)", tuples)
+
     .. versionadded:: 2.7
 
 .. note::


### PR DESCRIPTION
I had somehow forgotten about https://github.com/psycopg/psycopg2/pull/834 and could not fix the issues in that branch as I have no access to it somehow... Here is a new PR with the requested changes. I don't remember if I tested building the docs with this back in 2019, the syntax for the `extras.rst` might be broken but I know nothing about RST.

My original text: "hopefully this will make those functions more approachable for newbies. everyone tries it without proper sequences and then has to google."
