### PR TITLE
Updated from deprecated license_file parameter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ static_libpq=0
 libraries=
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
I was trying to install this package and got this error:
```text
...python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!

```
I removed the alias from [this table](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata) that it was complaining about.