### PR TITLE
Disable test_ssl_attribute on PG16+

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1920,6 +1920,7 @@ class TestConnectionInfo(ConnectingTestCase):
             self.conn.info.ssl_attribute('wat')
 
     @skip_before_libpq(9, 5)
+    @skip_after_libpq(16)
     def test_ssl_attribute(self):
         attribs = self.conn.info.ssl_attribute_names
         self.assert_(attribs)


### PR DESCRIPTION
PG15 changed the semantics of some ssl attributes (#1506), and a very similar regression test failure has now been observed again with PG16. Disable the test for now.