### PR TITLE
setup.py: handle more corner cases for pg_config

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Current release
 What's new in psycopg 2.9.7 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fix building when pg_config returns an empty string (:ticket:`#1599`).
 - Wheel package compiled against OpenSSL 1.1.1v.
 
 


### PR DESCRIPTION
- Differentiate between unexpected empty values and execution failure.
- Accept empty `--cppflags` and `--ldflags` output. Fixes #1599.
- Accept UTF-8 output from pg_config, for alternative client locales.
------
I took this opportunity to simplify a bit using `subprocess.run()`, since it looks like the minimum Python version is now 3.6. 

Originally I planned to set `run(..., encoding='ascii')`, but I realized that standard error messages coming back are not guaranteed to be in ASCII. So I switched to UTF-8 decoding (strict for stdout, lax for stderr), which should also handle more unusual installation paths. If that's too much change for a single bugfix, I can revert to ASCII-only.