### PR TITLE
Use `except psycopg2.Error as e` in example.

### DIFF
--- a/doc/src/module.rst
+++ b/doc/src/module.rst
@@ -184,7 +184,7 @@ available through the following exceptions:
 
             >>> try:
             ...     cur.execute("SELECT * FROM barf")
-            ... except psycopg2.Error, e:
+            ... except psycopg2.Error as e:
             ...     pass
 
             >>> e.diag.severity


### PR DESCRIPTION
This is a minor improvement for the doc.