### PR TITLE
Add a new kind of place holder

### DIFF
--- a/psycopg/utils.h
+++ b/psycopg/utils.h
@@ -59,7 +59,7 @@ HIDDEN RAISES BORROWED PyObject *psyco_set_error(
 
 HIDDEN PyObject *psyco_get_decimal_type(void);
 
-HIDDEN PyObject *Bytes_Format(PyObject *format, PyObject *args);
+HIDDEN PyObject *Bytes_Format(PyObject *format, PyObject *args, char place_holder);
 
 
 #endif /* !defined(UTILS_H) */


### PR DESCRIPTION
Based on the origin place holder '%', I added a new type of  place holder '$'. First i'd like to show the example: 

```
import psycopg2 as pg
conn = pg.connect(database = 'testdb' ...)
cursor = conn.cursor()

cursor.execute("delete from map")

for i in range(0, 10):
    cursor.execute("insert into map values($1, $2)", [i, i + 1], place_holder = '$')

cursor.execute("select * from map")
print(cursor.fetchall())

cursor.execute("select key from map where key > $2 and value > $1", [3, 5], place_holder = '$')
print(cursor.fetchall())

for i in range(0, 10):
    if i % 2 == 1:
        cursor.execute("delete from map where key = $1 and value = $2", [i, i + 1], place_holder = '$')

cursor.execute("select * from map")
print(cursor.fetchall())
```

the results it fetched from database are as following:

```
[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]
[(6,), (7,), (8,), (9,)]
[(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]
```

In my implementation, the way to use place holder '$' is the same as it's usage in bison.

When using '$', the argument 'place_holder' must be set to '$', otherwise it will use the default value '%'.

(Using default value is compatible to previous codes.)

At the same time, only one type of place holder is valid, which means when 'place_holder' is set to '$', all the character '%' will not be regarded as place holder, and vice versa.

If the sql needs to use character '$' after mogrify (but the place holder is set to '$'), you just need to use '$$' in the format string.
