### PR TITLE
AbstractConnectionPool does not pool more than "minconn" connections.

### DIFF
--- a/lib/pool.py
+++ b/lib/pool.py
@@ -102,7 +102,7 @@ class AbstractConnectionPool:
             if key is None:
                 raise PoolError("trying to put unkeyed connection")
 
-        if len(self._pool) < self.minconn and not close:
+        if len(self._pool) < self.maxconn and not close:
             # Return the connection into a consistent state before putting
             # it back into the pool
             if not conn.closed:


### PR DESCRIPTION
The pool should add the connection back into the pool as long as the pool is not larger than the maximum pool size.

The current code means that the reusable pool can never get bigger than "minconn". 

For example, if you want a pool that has zero minimum connections in it, there will never be a connection reused.