### PR TITLE
chore: update GitHub actions and Postgres image tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs build
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           repository: psycopg/psycopg-website
           event-type: psycopg2-commit

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build sdist
         run: ./scripts/build/build_sdist.sh
@@ -39,7 +39,7 @@ jobs:
 
     services:
       postgresql:
-        image: postgres:13
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: password
         ports:
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU for multi-arch build
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Cache libpq build
         uses: actions/cache@v3
@@ -81,7 +81,7 @@ jobs:
           key: libpq-${{ env.LIBPQ_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
@@ -114,7 +114,7 @@ jobs:
 
     services:
       postgresql:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: password
         ports:
@@ -140,10 +140,10 @@ jobs:
 
     steps:
       - name: Checkout repos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: ${{matrix.pyver}}-macosx_${{matrix.arch}}
           CIBW_ARCHS_MACOS: x86_64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Can enable to test an unreleased libpq version.
       - name: install libpq 16


### PR DESCRIPTION
After updating all GitHub actions I saw that old Postgres versions were used, so I updated them to 16 as well.

* build-sdist used 13
* build-linux used 14 (but libpq 16)