### PR TITLE
Made the log method a weakreference

### DIFF
--- a/lib/extras.py
+++ b/lib/extras.py
@@ -409,7 +409,9 @@ class LoggingConnection(_connection):
         """
         Public interface of the log method defined in initialize
         """
-        return self._log()(*args, **kwargs)
+        log = self._log()
+        if log:
+            return self._log()(*args, **kwargs)
 
     def filter(self, msg, curs):
         """Filter the query before logging it.


### PR DESCRIPTION
This is a fix for [issue 1670](https://github.com/psycopg/psycopg2/issues/1670). The issue outlines a bug where garbage collector cannot destroy the LoggingConnection object since it has a bound method called log on it.