### PR TITLE
Add connection.get_host_addr()

### DIFF
--- a/doc/src/connection.rst
+++ b/doc/src/connection.rst
@@ -910,6 +910,20 @@ The ``connection`` class
         .. versionadded:: 2.7
 
 
+    .. index::
+        pair: Connection; Parameters
+
+    .. method:: get_host_addr()
+
+        Get the server IP address of the active connection.
+
+        .. seealso:: libpq docs for `PQhostaddr()`__ for details.
+
+            .. __: https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQHOSTADDR
+
+        .. versionadded:: 2.9.10
+
+
 .. testcode::
     :hide:
 

--- a/psycopg/connection_type.c
+++ b/psycopg/connection_type.c
@@ -947,6 +947,16 @@ exit:
 #endif
 }
 
+#define psyco_conn_get_host_addr_doc \
+"get_host_addr() -- Get the server IP address of the active connection."
+
+static PyObject *
+psyco_conn_get_host_addr(connectionObject *self, PyObject *dummy)
+{
+    EXC_IF_CONN_CLOSED(self);
+
+    return Text_FromUTF8(PQhostaddr(self->pgconn));
+}
 
 /* lobject method - allocate a new lobject */
 
@@ -1220,6 +1230,8 @@ static struct PyMethodDef connectionObject_methods[] = {
      METH_VARARGS, psyco_conn_get_parameter_status_doc},
     {"get_dsn_parameters", (PyCFunction)psyco_conn_get_dsn_parameters,
      METH_NOARGS, psyco_conn_get_dsn_parameters_doc},
+    {"get_host_addr", (PyCFunction)psyco_conn_get_host_addr,
+     METH_NOARGS, psyco_conn_get_host_addr_doc},
     {"get_backend_pid", (PyCFunction)psyco_conn_get_backend_pid,
      METH_NOARGS, psyco_conn_get_backend_pid_doc},
     {"lobject", (PyCFunction)psyco_conn_lobject,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1826,6 +1826,9 @@ class TestConnectionInfo(ConnectingTestCase):
         self.assertEqual(d['dbname'], dbname)  # the only param we can check reliably
         self.assert_('password' not in d, d)
 
+    def test_host_addr(self):
+        self.assertEqual(self.conn.get_host_addr(), "")
+
     def test_status(self):
         self.assertEqual(self.conn.info.status, 0)
         self.assertEqual(self.bconn.info.status, 1)


### PR DESCRIPTION
In some use cases `connection.cancel()` is not usable because it may block the interpreter for a long time (as it does not release the GIL before calling `PQcancel` and does not support setting the tcp timeout for the cancel connection). An alternative approach to (asynchronously) cancel a query is to call `pg_cancel_backend` over a new connection. For this to work reliably, the connection should be established against the server IP address associated to the connection where the query is running. To this end, this PR adds a connection method to get the info using `PQhostaddr`.