### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           - {python: "3.10", postgres: "14"}
           - {python: "3.11", postgres: "15"}
           - {python: "3.12", postgres: "16"}
+          - {python: "3.13-dev", postgres: "16"}
 
           # Opposite extremes of the supported Py/PG range, other architecture
           - {python: "3.7", postgres: "16", architecture: "x86"}
@@ -27,6 +28,7 @@ jobs:
           - {python: "3.10", postgres: "13", architecture: "x86"}
           - {python: "3.11", postgres: "11", architecture: "x86"}
           - {python: "3.12", postgres: "10", architecture: "x86"}
+          - {python: "3.13-dev", postgres: "10", architecture: "x86"}
 
     env:
       PSYCOPG2_TESTDB: postgres

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 Current release
 ---------------
 
+What's new in psycopg 2.9.10 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add support for Python 3.13.
+
+
 What's new in psycopg 2.9.9
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/psycopg/utils.c
+++ b/psycopg/utils.c
@@ -392,7 +392,10 @@ psyco_set_error(PyObject *exc, cursorObject *curs, const char *msg)
 static int
 psyco_is_main_interp(void)
 {
-#if PY_VERSION_HEX >= 0x03080000
+#if PY_VERSION_HEX >= 0x030d0000
+    /* tested with Python 3.13.0a6 */
+    return PyInterpreterState_Get() == PyInterpreterState_Main();
+#elif PY_VERSION_HEX >= 0x03080000
     /* tested with Python 3.8.0a2 */
     return _PyInterpreterState_Get() == PyInterpreterState_Main();
 #else

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: C

--- a/tests/test_ipaddress.py
+++ b/tests/test_ipaddress.py
@@ -18,6 +18,7 @@
 
 from . import testutils
 import unittest
+import sys
 
 import psycopg2
 import psycopg2.extras
@@ -68,7 +69,12 @@ class NetworkingTestCase(testutils.ConnectingTestCase):
         self.assertEquals(cur.fetchone()[0], '127.0.0.1/24')
 
         cur.execute("select %s", [ip.ip_interface('::ffff:102:300/128')])
-        self.assertEquals(cur.fetchone()[0], '::ffff:102:300/128')
+
+        # The texual representation of addresses has changed in Python 3.13
+        if sys.version_info >= (3, 13):
+            self.assertEquals(cur.fetchone()[0], '::ffff:1.2.3.0/128')
+        else:
+            self.assertEquals(cur.fetchone()[0], '::ffff:102:300/128')
 
     @testutils.skip_if_crdb("cidr")
     def test_cidr_cast(self):
@@ -109,7 +115,12 @@ class NetworkingTestCase(testutils.ConnectingTestCase):
         self.assertEquals(cur.fetchone()[0], '127.0.0.0/24')
 
         cur.execute("select %s", [ip.ip_network('::ffff:102:300/128')])
-        self.assertEquals(cur.fetchone()[0], '::ffff:102:300/128')
+
+        # The texual representation of addresses has changed in Python 3.13
+        if sys.version_info >= (3, 13):
+            self.assertEquals(cur.fetchone()[0], '::ffff:1.2.3.0/128')
+        else:
+            self.assertEquals(cur.fetchone()[0], '::ffff:102:300/128')
 
 
 def test_suite():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {3.7,3.8,3.9,3.10,3.11,3.12}
+envlist = {3.7,3.8,3.9,3.10,3.11,3.12,3.13}
 
 [testenv]
 commands = make check


### PR DESCRIPTION
See individual commits.
I don't have all the bits to run tests, but I used these changes to build psycopg2 in Fedora and tests with Python 3.13 passed.
It would probably be good to add 3.13 to CI, but I'm not sure about the desired version matrix, so haven't done any changes there.
Related to #1692.