### PR TITLE
docs: tiny grammar fix "a" -> "one"

### DIFF
--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -814,7 +814,7 @@ is rolled back.
 When a cursor exits the ``with`` block it is closed, releasing any resource
 eventually associated with it. The state of the transaction is not affected.
 
-A connection can be used in more than a ``with`` statement
+A connection can be used in more than one ``with`` statement
 and each ``with`` block is effectively wrapped in a separate transaction::
 
     conn = psycopg2.connect(DSN)


### PR DESCRIPTION
Thanks very much for the work you do maintaining this @dvarrazzo ! :)

Here's a tiny grammar fix in the docs I came across which makes the sentence easier to understand.