### PR TITLE
docs: fixed a typo in doc/src/usage.rst file

### DIFF
--- a/doc/src/usage.rst
+++ b/doc/src/usage.rst
@@ -1053,7 +1053,7 @@ using the |lo_import|_ and |lo_export|_ libpq functions.
 
     If Psycopg was built with 64 bits large objects support (i.e. the first
     two conditions above are verified), the `psycopg2.__version__` constant
-    will contain the ``lo64`` flag.  If any of the contition is not met
+    will contain the ``lo64`` flag.  If any of the condition is not met
     several `!lobject` methods will fail if the arguments exceed 2GB.
 
 


### PR DESCRIPTION
While going through the psycopg2 documentation, I encountered a typo in the docs. So I thought to drop a quick fix.