### PR TITLE
chore: bundle libpq 17

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PIP_BREAK_SYSTEM_PACKAGES: "1"
-  LIBPQ_VERSION: "16.0"
+  LIBPQ_VERSION: "17.4"
   OPENSSL_VERSION: "1.1.1w"
 
 jobs:
@@ -163,7 +163,7 @@ jobs:
             export PYTHONPATH={project} &&
             python -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')"
           CIBW_ENVIRONMENT: >-
-            PG_VERSION=16
+            PG_VERSION=17
             PACKAGE_NAME=psycopg2-binary
             PSYCOPG2_TESTDB=postgres
             PATH="/tmp/libpq.build/bin:$PATH"

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 Current release
 ---------------
 
+What's new in psycopg 2.9.11
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Wheel package bundled with PostgreSQL 17 libpq in order to add support for
+  recent changes, such as ``daticulocale`` being renamed to ``datlocale``.
+
+
 What's new in psycopg 2.9.10
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scripts/build/build_libpq.sh
+++ b/scripts/build/build_libpq.sh
@@ -16,7 +16,7 @@ openssl_version="${OPENSSL_VERSION}"
 krb5_version="1.21.3"
 
 # last release: https://openldap.org/software/download/
-ldap_version="2.6.8"
+ldap_version="2.6.9"
 
 # last release: https://github.com/cyrusimap/cyrus-sasl/releases
 sasl_version="2.1.28"

--- a/scripts/build/build_macos_arm64.sh
+++ b/scripts/build/build_macos_arm64.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # set -x
 
 python_versions="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0"
-pg_version=16
+pg_version=17
 
 function log {
     echo "$@" >&2

--- a/scripts/build/wheel_macos_before_all.sh
+++ b/scripts/build/wheel_macos_before_all.sh
@@ -3,7 +3,7 @@
 # Configure the environment needed to build wheel packages on Mac OS.
 # This script is designed to be used by cibuildwheel as CIBW_BEFORE_ALL_MACOS
 #
-# The PG_VERSION env var must be set to a Postgres major version (e.g. 16).
+# The PG_VERSION env var must be set to a Postgres major version (e.g. 17).
 
 set -euo pipefail
 set -x

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ import configparser
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.10'
+PSYCOPG_VERSION = '2.9.11'
 
 
 # note: if you are changing the list of supported Python version please fix


### PR DESCRIPTION
Bundle libpq 17 in the binary wheels.

I've had reports of issues using psycopg2 v2.9.10 with PostgreSQL v17 on the server side:

```
ERROR:  column d.daticulocale does not exist
LINE 6:        d.daticulocale as "ICU Locale",
               ^
HINT:  Perhaps you meant to reference the column "d.datlocale".
```

The column was renamed. See https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d