### PR TITLE
feat: redact passwords in PostgreSQL connection URIs to enhance security

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@ What's new in psycopg 2.9.12
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fix infinite loop with malformed interval (:ticket:`1835`).
+- Redact passwords from PostgreSQL connection URIs embedded in exception
+  messages (e.g. ``postgresql://user:pass@host`` becomes
+  ``postgresql://user:***@host``) to avoid leaking credentials into
+  application logs when ``parse_dsn()`` or ``connect()`` fails.
 
 
 What's new in psycopg 2.9.11

--- a/psycopg/connection_int.c
+++ b/psycopg/connection_int.c
@@ -736,7 +736,7 @@ _conn_sync_connect(connectionObject *self, const char *dsn)
     else if (PQstatus(self->pgconn) == CONNECTION_BAD)
     {
         Dprintf("conn_connect: PQconnectdb(%s) returned BAD", dsn);
-        PyErr_SetString(OperationalError, PQerrorMessage(self->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(self->pgconn));
         return -1;
     }
 
@@ -782,7 +782,7 @@ _conn_async_connect(connectionObject *self, const char *dsn)
     else if (PQstatus(pgconn) == CONNECTION_BAD)
     {
         Dprintf("conn_connect: PQconnectdb(%s) returned BAD", dsn);
-        PyErr_SetString(OperationalError, PQerrorMessage(pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(pgconn));
         return -1;
     }
 
@@ -849,7 +849,7 @@ _conn_poll_connecting(connectionObject *self)
         if (!(msg && *msg)) {
             msg = "asynchronous connection failed";
         }
-        PyErr_SetString(OperationalError, msg);
+        psyco_set_error(OperationalError, NULL, msg);
         res = PSYCO_POLL_ERROR;
         break;
     }
@@ -883,7 +883,7 @@ _conn_poll_advance_write(connectionObject *self)
         res = PSYCO_POLL_WRITE;
         break;
     case -1:  /* error */
-        PyErr_SetString(OperationalError, PQerrorMessage(self->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(self->pgconn));
         res = PSYCO_POLL_ERROR;
         break;
     default:
@@ -1008,7 +1008,7 @@ _conn_poll_setup_async(connectionObject *self)
             Dprintf("conn_poll: status -> CONN_STATUS_DATESTYLE");
             self->status = CONN_STATUS_DATESTYLE;
             if (0 == pq_send_query(self, psyco_datestyle)) {
-                PyErr_SetString(OperationalError, PQerrorMessage(self->pgconn));
+                psyco_set_error(OperationalError, NULL, PQerrorMessage(self->pgconn));
                 break;
             }
             Dprintf("conn_poll: async_status -> ASYNC_WRITE");
@@ -1559,6 +1559,8 @@ conn_set_error(connectionObject *self, const char *msg)
         self->error = NULL;
     }
     if (msg && *msg) {
-        self->error = strdup(msg);
+        char *red = psyco_redact_conninfo_msg(msg);
+        self->error = strdup(red ? red : msg);
+        PyMem_Free(red);
     }
 }

--- a/psycopg/conninfo_type.c
+++ b/psycopg/conninfo_type.c
@@ -334,12 +334,17 @@ static PyObject *
 error_message_get(connInfoObject *self)
 {
     const char *val;
+    char *red;
+    PyObject *rv;
 
     val = PQerrorMessage(self->conn->pgconn);
     if (!val || !val[0]) {
         Py_RETURN_NONE;
     }
-    return conn_text_from_chars(self->conn, val);
+    red = psyco_redact_conninfo_msg(val);
+    rv = conn_text_from_chars(self->conn, red ? red : val);
+    PyMem_Free(red);
+    return rv;
 }
 
 

--- a/psycopg/pqpath.c
+++ b/psycopg/pqpath.c
@@ -96,6 +96,8 @@ pq_raise(connectionObject *conn, cursorObject *curs, PGresult **pgres)
     PyObject *exc = NULL;
     const char *err = NULL;
     const char *err2 = NULL;
+    const char *safe_err = NULL;
+    char *red_err = NULL;
     const char *code = NULL;
     PyObject *pyerr = NULL;
     PyObject *pgerror = NULL, *pgcode = NULL;
@@ -140,6 +142,9 @@ pq_raise(connectionObject *conn, cursorObject *curs, PGresult **pgres)
         return;
     }
 
+    red_err = psyco_redact_conninfo_msg(err);
+    safe_err = red_err ? red_err : err;
+
     /* Analyze the message and try to deduce the right exception kind
        (only if we got the SQLSTATE from the pgres, obviously) */
     if (code != NULL) {
@@ -152,13 +157,13 @@ pq_raise(connectionObject *conn, cursorObject *curs, PGresult **pgres)
     }
 
     /* try to remove the initial "ERROR: " part from the postgresql error */
-    err2 = strip_severity(err);
+    err2 = strip_severity(safe_err);
     Dprintf("pq_raise: err2=%s", err2);
 
     /* decode now the details of the error, because after psyco_set_error
      * decoding will fail.
      */
-    if (!(pgerror = conn_text_from_chars(conn, err))) {
+    if (!(pgerror = conn_text_from_chars(conn, safe_err))) {
         /* we can't really handle an exception while handling this error
          * so just print it. */
         PyErr_Print();
@@ -196,6 +201,8 @@ pq_raise(connectionObject *conn, cursorObject *curs, PGresult **pgres)
 
     Py_XDECREF(pgerror);
     Py_XDECREF(pgcode);
+
+    PyMem_Free(red_err);
 }
 
 /* pq_clear_async - clear the effects of a previous async query
@@ -716,7 +723,7 @@ pq_get_result_async(connectionObject *conn)
             conn->closed = 2;
         }
 
-        PyErr_SetString(OperationalError, PQerrorMessage(conn->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(conn->pgconn));
         goto exit;
     }
 
@@ -851,8 +858,7 @@ _pq_execute_sync(cursorObject *curs, const char *query, int no_result, int no_be
         pthread_mutex_unlock(&(conn->lock));
         Py_BLOCK_THREADS;
         if (!PyErr_Occurred()) {
-            PyErr_SetString(OperationalError,
-                            PQerrorMessage(conn->pgconn));
+            psyco_set_error(OperationalError, NULL, PQerrorMessage(conn->pgconn));
         }
         return -1;
     }
@@ -903,8 +909,7 @@ _pq_execute_async(cursorObject *curs, const char *query, int no_result)
         }
         pthread_mutex_unlock(&(conn->lock));
         Py_BLOCK_THREADS;
-        PyErr_SetString(OperationalError,
-                        PQerrorMessage(conn->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(conn->pgconn));
         return -1;
     }
     Dprintf("pq_execute: async query sent to backend");
@@ -924,8 +929,7 @@ _pq_execute_async(cursorObject *curs, const char *query, int no_result)
         /* there was an error */
         pthread_mutex_unlock(&(conn->lock));
         Py_BLOCK_THREADS;
-        PyErr_SetString(OperationalError,
-                        PQerrorMessage(conn->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(conn->pgconn));
         return -1;
     }
 
@@ -947,7 +951,7 @@ pq_execute(cursorObject *curs, const char *query, int async, int no_result, int 
     /* check status of connection, raise error if not OK */
     if (PQstatus(curs->conn->pgconn) != CONNECTION_OK) {
         Dprintf("pq_execute: connection NOT OK");
-        PyErr_SetString(OperationalError, PQerrorMessage(curs->conn->pgconn));
+        psyco_set_error(OperationalError, NULL, PQerrorMessage(curs->conn->pgconn));
         return -1;
     }
     Dprintf("pq_execute: pg connection at %p OK", curs->conn->pgconn);

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -139,7 +139,12 @@ parse_dsn(PyObject *self, PyObject *args, PyObject *kwargs)
     options = PQconninfoParse(Bytes_AS_STRING(dsn), &err);
     if (options == NULL) {
         if (err != NULL) {
-            PyErr_Format(ProgrammingError, "invalid dsn: %s", err);
+            /* `err` from libpq may quote the raw DSN/URI verbatim; redact
+             * any embedded credentials before surfacing to Python. */
+            char *safe = psyco_redact_conninfo_msg(err);
+            PyErr_Format(ProgrammingError, "invalid dsn: %s",
+                         safe ? safe : err);
+            PyMem_Free(safe);
             PQfreemem(err);
         } else {
             PyErr_SetString(OperationalError, "PQconninfoParse() failed");
@@ -454,8 +459,11 @@ encrypt_password(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     else {
         const char *msg = PQerrorMessage(conn->pgconn);
+        const char *raw = (msg && msg[0]) ? msg : "no reason given";
+        char *safe = psyco_redact_conninfo_msg(raw);
         PyErr_Format(ProgrammingError,
-            "password encryption failed: %s", msg ? msg : "no reason given");
+            "password encryption failed: %s", safe ? safe : raw);
+        PyMem_Free(safe);
         goto exit;
     }
 

--- a/psycopg/utils.c
+++ b/psycopg/utils.c
@@ -35,6 +35,211 @@
 #include <string.h>
 #include <stdlib.h>
 
+/* ---------- connection string credential redaction -----------------------
+ *
+ * libpq may embed verbatim the connection URI the user passed into its
+ * diagnostic strings (e.g. `invalid URI query parameter: "x" in
+ * "postgresql://joe:hunter2@host/db"`). When those strings surface through
+ * an exception they leak credentials into application logs, CI output and
+ * APM systems. To prevent that we sanitize every diagnostic we surface as
+ * the message of a Python exception.
+ *
+ * The sanitizer is intentionally narrow and byte-oriented:
+ *
+ *   - it only rewrites the "userinfo" segment of a URI whose scheme starts
+ *     with "postgres" (covers "postgres", "postgresql", "postgresql+driver",
+ *     etc.);
+ *   - in that segment it preserves the username (useful for diagnostics,
+ *     matching the convention of SQLAlchemy/Django) and replaces the
+ *     password with a fixed placeholder, yielding `user:***@host`;
+ *   - bytes are scanned one at a time, so UTF-8 and other ASCII-compatible
+ *     encodings emitted by libpq are safe (the delimiters we match `://`,
+ *     `@`, `/`, `?`, `#` are all single-byte ASCII and never occur inside
+ *     UTF-8 continuation bytes).
+ *
+ * The function always returns a freshly-allocated copy of the input (or
+ * NULL on allocation failure) so callers have a uniform ownership model.
+ */
+
+#define PSYCO_REDACTED "***"
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+} strbuf;
+
+static int
+strbuf_reserve(strbuf *sb, size_t extra)
+{
+    size_t need = sb->len + extra + 1;
+    if (need <= sb->cap) {
+        return 0;
+    }
+    size_t cap = sb->cap ? sb->cap : 64;
+    while (cap < need) {
+        cap *= 2;
+    }
+    char *tmp = PyMem_Realloc(sb->buf, cap);
+    if (!tmp) {
+        PyMem_Free(sb->buf);
+        sb->buf = NULL;
+        return -1;
+    }
+    sb->buf = tmp;
+    sb->cap = cap;
+    return 0;
+}
+
+static int
+strbuf_append(strbuf *sb, const char *s, size_t n)
+{
+    if (strbuf_reserve(sb, n) < 0) {
+        return -1;
+    }
+    memcpy(sb->buf + sb->len, s, n);
+    sb->len += n;
+    sb->buf[sb->len] = '\0';
+    return 0;
+}
+
+static int
+is_scheme_char(unsigned char c)
+{
+    /* RFC 3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+    return (c >= 'a' && c <= 'z')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9')
+        || c == '+' || c == '-' || c == '.';
+}
+
+/* True iff [s, s+n) equals "postgres" prefix case-insensitively. */
+static int
+is_postgres_scheme(const char *s, size_t n)
+{
+    static const char prefix[] = "postgres";
+    size_t pn = sizeof(prefix) - 1;
+    if (n < pn) {
+        return 0;
+    }
+    for (size_t i = 0; i < pn; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c >= 'A' && c <= 'Z') {
+            c = (unsigned char)(c - 'A' + 'a');
+        }
+        if (c != (unsigned char)prefix[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Walk back from the `://` colon to find the start of the scheme. Returns a
+ * pointer inside [start, colon] that is either start or the character just
+ * after the last non-scheme byte. */
+static const char *
+scheme_start(const char *start, const char *colon)
+{
+    const char *p = colon;
+    while (p > start && is_scheme_char((unsigned char)p[-1])) {
+        p--;
+    }
+    return p;
+}
+
+char *
+psyco_redact_conninfo_msg(const char *msg)
+{
+    strbuf out = {NULL, 0, 0};
+
+    if (!msg) {
+        return NULL;
+    }
+
+    const char *base = msg;
+    const char *p = msg;
+
+    while (*p) {
+        /* Look for "://" — the authority separator of any URI. */
+        if (!(p[0] == ':' && p[1] == '/' && p[2] == '/')) {
+            p++;
+            continue;
+        }
+
+        /* Confirm this is a postgres-family URI. */
+        const char *s_beg = scheme_start(base, p);
+        size_t s_len = (size_t)(p - s_beg);
+        if (!is_postgres_scheme(s_beg, s_len)) {
+            p++;
+            continue;
+        }
+
+        /* Emit everything up to and including `://`. */
+        if (strbuf_append(&out, base, (size_t)(p - base + 3)) < 0) {
+            return NULL;
+        }
+
+        /* The authority ends at the next `/`, `?`, `#` or string end. */
+        const char *auth_beg = p + 3;
+        const char *auth_end = auth_beg;
+        while (*auth_end && *auth_end != '/'
+               && *auth_end != '?' && *auth_end != '#') {
+            auth_end++;
+        }
+
+        /* userinfo (if any) is terminated by the rightmost `@` in the
+         * authority. Scanning for the first `@` is safe because `@` is
+         * not allowed unescaped in the host portion of a URI. */
+        const char *at = memchr(auth_beg, '@',
+                                (size_t)(auth_end - auth_beg));
+
+        if (at && at > auth_beg) {
+            /* Within userinfo, the password (if present) follows the
+             * first `:`. Keep the username, replace the password. */
+            const char *colon = memchr(auth_beg, ':',
+                                       (size_t)(at - auth_beg));
+            if (colon) {
+                /* user:pass@ -> user:***@ */
+                if (strbuf_append(&out, auth_beg,
+                                  (size_t)(colon - auth_beg + 1)) < 0) {
+                    return NULL;
+                }
+                if (strbuf_append(&out, PSYCO_REDACTED,
+                                  sizeof(PSYCO_REDACTED) - 1) < 0) {
+                    return NULL;
+                }
+            }
+            else {
+                /* userinfo without password: keep it as-is. */
+                if (strbuf_append(&out, auth_beg,
+                                  (size_t)(at - auth_beg)) < 0) {
+                    return NULL;
+                }
+            }
+            if (strbuf_append(&out, at, (size_t)(auth_end - at)) < 0) {
+                return NULL;
+            }
+        }
+        else {
+            /* No userinfo at all: copy the host segment verbatim. */
+            if (strbuf_append(&out, auth_beg,
+                              (size_t)(auth_end - auth_beg)) < 0) {
+                return NULL;
+            }
+        }
+
+        base = auth_end;
+        p = auth_end;
+    }
+
+    /* Emit the tail. strbuf_append always allocates, so `out.buf` is
+     * non-NULL on success even when the input (and tail) is empty. */
+    if (strbuf_append(&out, base, strlen(base)) < 0) {
+        return NULL;
+    }
+    return out.buf;
+}
+
 /* Escape a string for sql inclusion.
  *
  * The function must be called holding the GIL.
@@ -116,12 +321,15 @@ psyco_escape_identifier(connectionObject *conn, const char *str, Py_ssize_t len)
 
     rv = PQescapeIdentifier(conn->pgconn, str, len);
     if (!rv) {
-        char *msg;
-        msg = PQerrorMessage(conn->pgconn);
+        const char *msg = PQerrorMessage(conn->pgconn);
         if (!msg || !msg[0]) {
             msg = "no message provided";
         }
-        PyErr_Format(InterfaceError, "failed to escape identifier: %s", msg);
+        /* libpq error strings can embed the connection URI; redact. */
+        char *safe = psyco_redact_conninfo_msg(msg);
+        PyErr_Format(InterfaceError,
+            "failed to escape identifier: %s", safe ? safe : msg);
+        PyMem_Free(safe);
     }
 
 exit:
@@ -354,23 +562,25 @@ psyco_set_error(PyObject *exc, cursorObject *curs, const char *msg)
 {
     PyObject *pymsg;
     PyObject *err = NULL;
-    connectionObject *conn = NULL;
+    connectionObject *conn = curs ? ((cursorObject *)curs)->conn : NULL;
+    /* Scrub credentials embedded in the libpq diagnostic (if any) before
+     * handing the message off to the exception. */
+    char *red = msg ? psyco_redact_conninfo_msg(msg) : NULL;
+    const char *safe = red ? red : msg;
 
-    if (curs) {
-        conn = ((cursorObject *)curs)->conn;
-    }
-
-    if ((pymsg = conn_text_from_chars(conn, msg))) {
+    if ((pymsg = conn_text_from_chars(conn, safe))) {
         err = PyObject_CallFunctionObjArgs(exc, pymsg, NULL);
         Py_DECREF(pymsg);
     }
-    else {
-        /* what's better than an error in an error handler in the morning?
-         * Anyway, some error was set, refcount is ok... get outta here. */
+    PyMem_Free(red);
+
+    if (!err) {
+        /* An error occurred while building the exception; whatever was
+         * raised is already set, so just bail. */
         return NULL;
     }
 
-    if (err && PyObject_TypeCheck(err, &errorType)) {
+    if (PyObject_TypeCheck(err, &errorType)) {
         errorObject *perr = (errorObject *)err;
         if (curs) {
             Py_CLEAR(perr->cursor);
@@ -379,11 +589,8 @@ psyco_set_error(PyObject *exc, cursorObject *curs, const char *msg)
         }
     }
 
-    if (err) {
-        PyErr_SetObject(exc, err);
-        Py_DECREF(err);
-    }
-
+    PyErr_SetObject(exc, err);
+    Py_DECREF(err);
     return err;
 }
 

--- a/psycopg/utils.h
+++ b/psycopg/utils.h
@@ -63,5 +63,11 @@ HIDDEN BORROWED PyObject *psyco_weakref_get_object(PyObject *);
 
 HIDDEN PyObject *Bytes_Format(PyObject *format, PyObject *args);
 
+/* Return a freshly-allocated copy of `msg` with credentials that may be
+ * embedded in PostgreSQL connection URIs replaced by a placeholder.
+ * Returns NULL only if `msg` is NULL or allocation fails. The caller owns
+ * the result and must PyMem_Free() it. */
+HIDDEN char *psyco_redact_conninfo_msg(const char *msg);
+
 
 #endif /* !defined(UTILS_H) */

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -462,6 +462,38 @@ class ParseDsnTestCase(ConnectingTestCase):
                             "URI was not exposed in error message")
         self.assertTrue(raised, "ProgrammingError raised due to invalid URI")
 
+    @skip_before_libpq(9, 2)
+    def test_parse_dsn_uri_password_redacted(self):
+        # libpq echoes the conninfo string verbatim for some errors (e.g.
+        # an unknown compound scheme like "postgresql+driver://"); confirm
+        # the password never appears in the exception message.
+        cases = [
+            ('postgresql+driver://alice:hunter2@host/db', 'hunter2'),
+            ('postgresql+asyncpg://joe:TopSecret@host:5432/db', 'TopSecret'),
+            ('postgres+psycopg://bob:S3cret!@host/db', 'S3cret!'),
+        ]
+        for url, password in cases:
+            try:
+                ext.parse_dsn(url)
+            except psycopg2.Error as e:
+                msg = str(e)
+                self.assertNotIn(password, msg)
+                # When libpq echoes the URI, the password segment is replaced
+                # by a fixed placeholder (username is preserved).
+                if '://' in msg:
+                    self.assertIn(':***@', msg,
+                        "password should be replaced by '***' placeholder"
+                        " in: %r" % msg)
+
+    @skip_before_libpq(9, 2)
+    def test_parse_dsn_uri_no_password_preserved(self):
+        # When the URI has no password the redactor must not inject a
+        # placeholder.
+        try:
+            ext.parse_dsn('postgresql+driver://user_only@host/db')
+        except psycopg2.Error as e:
+            self.assertNotIn('***', str(e))
+
     def test_unicode_value(self):
         snowman = "\u2603"
         d = ext.parse_dsn('dbname=' + snowman)


### PR DESCRIPTION
Existing `ParseDsnTestCase` and `MakeDsnTestCase` tests continue to
pass.
```text
tests/test_connection.py::ParseDsnTestCase::test_bad_param                                  PASSED
tests/test_connection.py::ParseDsnTestCase::test_parse_dsn                                  PASSED
tests/test_connection.py::ParseDsnTestCase::test_parse_dsn_uri                              PASSED
tests/test_connection.py::ParseDsnTestCase::test_parse_dsn_uri_no_password_preserved        PASSED
tests/test_connection.py::ParseDsnTestCase::test_parse_dsn_uri_password_redacted            PASSED
tests/test_connection.py::ParseDsnTestCase::test_str_subclass                               PASSED
tests/test_connection.py::ParseDsnTestCase::test_unicode_key                                PASSED
tests/test_connection.py::ParseDsnTestCase::test_unicode_value                              PASSED
```
## Compatibility
- **ABI**: no public C API changes. The new symbol
  `psyco_redact_conninfo_msg` is `HIDDEN`.
- **Python API**: no signature changes. Only the *text* of exception
  messages changes, and only when the message contained credentials
  (which callers should not have been relying on).
- **libpq versions**: no new libpq dependency; redaction is performed
  on the Python side after libpq returns the string.
## Files changed
```
NEWS                     |   4 +
psycopg/connection_int.c |  14 ++-
psycopg/conninfo_type.c  |   7 +-
psycopg/pqpath.c         |  24 +++--
psycopg/psycopgmodule.c  |  12 ++-
psycopg/utils.c          | 243 ++++++++++++++++++++++++++++++++++++++++++-----
psycopg/utils.h          |   6 ++
tests/test_connection.py |  32 ++++++
8 files changed, 305 insertions(+), 37 deletions(-)
```
## Checklist
- [x] Fix implemented at the psycopg boundary (not dependent on a libpq
      change).
- [x] Single sanitization function used at every egress point.
- [x] Tests cover both "password redacted" and "no password preserved"
      cases, plus compound schemes (`postgresql+driver://`).
- [x] `NEWS` entry added.
- [x] No new public API surface; no ABI break.
## Related
- Issue: [psycopg/psycopg2#1837](https://github.com/psycopg/psycopg2/issues/1837)